### PR TITLE
Additional HTTP query to fetch the data

### DIFF
--- a/src/Http/Controllers/DistrictController.php
+++ b/src/Http/Controllers/DistrictController.php
@@ -13,9 +13,11 @@ class DistrictController
         return NusaResource::collection($request->apply($district));
     }
 
-    public function show(int $district)
+    public function show(NusaRequest $request, int $district)
     {
         $district = District::query()->findOrFail($district);
+
+        $district->load($request->relations($district));
 
         return new NusaResource($district);
     }

--- a/src/Http/Controllers/DistrictController.php
+++ b/src/Http/Controllers/DistrictController.php
@@ -2,20 +2,26 @@
 
 namespace Creasi\Nusa\Http\Controllers;
 
+use Creasi\Nusa\Contracts\District;
 use Creasi\Nusa\Http\Requests\NusaRequest;
 use Creasi\Nusa\Http\Resources\NusaResource;
-use Creasi\Nusa\Models\District;
 
-class DistrictController
+final class DistrictController
 {
-    public function index(NusaRequest $request, District $district)
+    public function __construct(
+        private District $model
+    ) {
+        // .
+    }
+
+    public function index(NusaRequest $request)
     {
-        return NusaResource::collection($request->apply($district));
+        return NusaResource::collection($request->apply($this->model));
     }
 
     public function show(NusaRequest $request, int $district)
     {
-        $district = District::query()->findOrFail($district);
+        $district = $this->model->findOrFail($district);
 
         $district->load($request->relations($district));
 
@@ -24,7 +30,7 @@ class DistrictController
 
     public function villages(int $district)
     {
-        $district = District::query()->findOrFail($district);
+        $district = $this->model->findOrFail($district);
 
         return NusaResource::collection($district->villages()->paginate());
     }

--- a/src/Http/Controllers/ProvinceController.php
+++ b/src/Http/Controllers/ProvinceController.php
@@ -2,20 +2,26 @@
 
 namespace Creasi\Nusa\Http\Controllers;
 
+use Creasi\Nusa\Contracts\Province;
 use Creasi\Nusa\Http\Requests\NusaRequest;
 use Creasi\Nusa\Http\Resources\NusaResource;
-use Creasi\Nusa\Models\Province;
 
-class ProvinceController
+final class ProvinceController
 {
-    public function index(NusaRequest $request, Province $province)
+    public function __construct(
+        private Province $model
+    ) {
+        // .
+    }
+
+    public function index(NusaRequest $request)
     {
-        return NusaResource::collection($request->apply($province));
+        return NusaResource::collection($request->apply($this->model));
     }
 
     public function show(NusaRequest $request, int $province)
     {
-        $province = Province::query()->find($province);
+        $province = $this->model->find($province);
 
         $province->load($request->relations($province));
 
@@ -24,21 +30,21 @@ class ProvinceController
 
     public function regencies(int $province)
     {
-        $province = Province::query()->findOrFail($province);
+        $province = $this->model->findOrFail($province);
 
         return NusaResource::collection($province->regencies()->paginate());
     }
 
     public function districts(int $province)
     {
-        $province = Province::query()->findOrFail($province);
+        $province = $this->model->findOrFail($province);
 
         return NusaResource::collection($province->districts()->paginate());
     }
 
     public function villages(int $province)
     {
-        $province = Province::query()->findOrFail($province);
+        $province = $this->model->findOrFail($province);
 
         return NusaResource::collection($province->villages()->paginate());
     }

--- a/src/Http/Controllers/ProvinceController.php
+++ b/src/Http/Controllers/ProvinceController.php
@@ -13,9 +13,11 @@ class ProvinceController
         return NusaResource::collection($request->apply($province));
     }
 
-    public function show(int $province)
+    public function show(NusaRequest $request, int $province)
     {
         $province = Province::query()->find($province);
+
+        $province->load($request->relations($province));
 
         return new NusaResource($province);
     }

--- a/src/Http/Controllers/RegencyController.php
+++ b/src/Http/Controllers/RegencyController.php
@@ -2,20 +2,26 @@
 
 namespace Creasi\Nusa\Http\Controllers;
 
+use Creasi\Nusa\Contracts\Regency;
 use Creasi\Nusa\Http\Requests\NusaRequest;
 use Creasi\Nusa\Http\Resources\NusaResource;
-use Creasi\Nusa\Models\Regency;
 
-class RegencyController
+final class RegencyController
 {
-    public function index(NusaRequest $request, Regency $regency)
+    public function __construct(
+        private Regency $model
+    ) {
+        // .
+    }
+
+    public function index(NusaRequest $request)
     {
-        return NusaResource::collection($request->apply($regency));
+        return NusaResource::collection($request->apply($this->model));
     }
 
     public function show(NusaRequest $request, int $regency)
     {
-        $regency = Regency::query()->findOrFail($regency);
+        $regency = $this->model->findOrFail($regency);
 
         $regency->load($request->relations($regency));
 
@@ -24,14 +30,14 @@ class RegencyController
 
     public function districts(int $regency)
     {
-        $regency = Regency::query()->findOrFail($regency);
+        $regency = $this->model->findOrFail($regency);
 
         return NusaResource::collection($regency->districts()->paginate());
     }
 
     public function villages(int $regency)
     {
-        $regency = Regency::query()->findOrFail($regency);
+        $regency = $this->model->findOrFail($regency);
 
         return NusaResource::collection($regency->villages()->paginate());
     }

--- a/src/Http/Controllers/RegencyController.php
+++ b/src/Http/Controllers/RegencyController.php
@@ -13,9 +13,11 @@ class RegencyController
         return NusaResource::collection($request->apply($regency));
     }
 
-    public function show(int $regency)
+    public function show(NusaRequest $request, int $regency)
     {
         $regency = Regency::query()->findOrFail($regency);
+
+        $regency->load($request->relations($regency));
 
         return new NusaResource($regency);
     }

--- a/src/Http/Controllers/VillageController.php
+++ b/src/Http/Controllers/VillageController.php
@@ -2,20 +2,26 @@
 
 namespace Creasi\Nusa\Http\Controllers;
 
+use Creasi\Nusa\Contracts\Village;
 use Creasi\Nusa\Http\Requests\NusaRequest;
 use Creasi\Nusa\Http\Resources\NusaResource;
-use Creasi\Nusa\Models\Village;
 
-class VillageController
+final class VillageController
 {
-    public function index(NusaRequest $request, Village $village)
+    public function __construct(
+        private Village $model
+    ) {
+        // .
+    }
+
+    public function index(NusaRequest $request)
     {
-        return NusaResource::collection($request->apply($village));
+        return NusaResource::collection($request->apply($this->model));
     }
 
     public function show(NusaRequest $request, int $village)
     {
-        $village = Village::query()->findOrFail($village);
+        $village = $this->model->findOrFail($village);
 
         $village->load($request->relations($village));
 

--- a/src/Http/Controllers/VillageController.php
+++ b/src/Http/Controllers/VillageController.php
@@ -13,9 +13,11 @@ class VillageController
         return NusaResource::collection($request->apply($village));
     }
 
-    public function show(int $village)
+    public function show(NusaRequest $request, int $village)
     {
         $village = Village::query()->findOrFail($village);
+
+        $village->load($request->relations($village));
 
         return new NusaResource($village);
     }

--- a/src/Http/Requests/NusaRequest.php
+++ b/src/Http/Requests/NusaRequest.php
@@ -2,11 +2,10 @@
 
 namespace Creasi\Nusa\Http\Requests;
 
-use Creasi\Nusa\Models\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 
-class NusaRequest extends FormRequest
+final class NusaRequest extends FormRequest
 {
     public function rules(): array
     {
@@ -21,7 +20,11 @@ class NusaRequest extends FormRequest
         ];
     }
 
-    public function apply(Model $model)
+    /**
+     * @param  \Creasi\Nusa\Models\Model  $model
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function apply($model)
     {
         $result = $model->load($this->relations($model))->query()
             ->when($this->has('search'), function (Builder $query) {
@@ -35,9 +38,10 @@ class NusaRequest extends FormRequest
     }
 
     /**
+     * @param  \Creasi\Nusa\Models\Model  $model
      * @return string[]
      */
-    public function relations(Model $model): array
+    public function relations($model): array
     {
         return \array_filter((array) $this->query('with', []), fn (string $relate) => \method_exists($model, $relate));
     }

--- a/src/Http/Resources/NusaResource.php
+++ b/src/Http/Resources/NusaResource.php
@@ -23,42 +23,56 @@ final class NusaResource extends JsonResource
 
     public function toArray(Request $request): array
     {
-        $arr = [
-            $this->resource->getKeyName() => $this->resource->getKey(),
-            'name' => $this->resource->name,
-            'district_code' => $this->resource->district_code,
-            'regency_code' => $this->resource->regency_code,
-            'province_code' => $this->resource->province_code,
-            'postal_code' => $this->when(
-                $this->isVillage(),
-                fn () => $this->resource->postal_code
-            ),
-        ];
-
-        $with = (array) $request->query('with', []);
-
-        if (\in_array('postal_codes', $with, true)) {
-            $arr['postal_codes'] = $this->when(
-                ! $this->isVillage(),
-                fn () => $this->resource->postal_codes
-            );
-        }
-
-        if (\in_array('coordinates', $with, true)) {
-            $arr['latitude'] = $this->resource->latitude;
-            $arr['longitude'] = $this->resource->longitude;
-            $arr['coordinates'] = $this->resource->coordinates;
-        }
+        $with = $request->query('with', []);
+        $arr = $this->normalize($this->resource, $with);
 
         foreach ($with as $relation) {
-            $arr[$relation] = $this->whenLoaded($relation);
+            $arr[$relation] = $this->whenLoaded($relation, function () use ($relation, $with) {
+                $relate = $this->resource->$relation;
+
+                if ($relate instanceof Model) {
+                    return $this->normalize($relate, $with);
+                }
+
+                return $relate->map(fn (Model $model) => $this->normalize($model, $with));
+            });
         }
 
         return \array_filter($arr);
     }
 
-    private function isVillage(): bool
+    private function normalize(Model $resource, array $with = []): array
     {
-        return $this->resource instanceof Village;
+        $arr = [
+            $resource->getKeyName() => $resource->getKey(),
+            'name' => $resource->name,
+            'district_code' => $resource->district_code,
+            'regency_code' => $resource->regency_code,
+            'province_code' => $resource->province_code,
+            'postal_code' => $this->when(
+                $this->isVillage($resource),
+                fn () => $resource->postal_code
+            ),
+        ];
+
+        if (\in_array('postal_codes', $with, true)) {
+            $arr['postal_codes'] = $this->when(
+                ! $this->isVillage($resource),
+                fn () => $resource->postal_codes
+            );
+        }
+
+        if (\in_array('coordinates', $with, true)) {
+            $arr['latitude'] = $resource->latitude;
+            $arr['longitude'] = $resource->longitude;
+            $arr['coordinates'] = $resource->coordinates;
+        }
+
+        return \array_filter($arr);
+    }
+
+    private function isVillage(Model $resource): bool
+    {
+        return $resource instanceof Village;
     }
 }

--- a/src/Http/Resources/NusaResource.php
+++ b/src/Http/Resources/NusaResource.php
@@ -10,7 +10,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 /**
  * @property-read Model $resource
  */
-class NusaResource extends JsonResource
+final class NusaResource extends JsonResource
 {
     public function __construct($resource)
     {

--- a/src/Http/Resources/NusaResource.php
+++ b/src/Http/Resources/NusaResource.php
@@ -2,7 +2,9 @@
 
 namespace Creasi\Nusa\Http\Resources;
 
+use Creasi\Nusa\Contracts\Village;
 use Creasi\Nusa\Models\Model;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
@@ -10,5 +12,53 @@ use Illuminate\Http\Resources\Json\JsonResource;
  */
 class NusaResource extends JsonResource
 {
-    //
+    public function __construct($resource)
+    {
+        parent::__construct($resource);
+
+        $this->additional([
+            'meta' => [],
+        ]);
+    }
+
+    public function toArray(Request $request): array
+    {
+        $arr = [
+            $this->resource->getKeyName() => $this->resource->getKey(),
+            'name' => $this->resource->name,
+            'district_code' => $this->resource->district_code,
+            'regency_code' => $this->resource->regency_code,
+            'province_code' => $this->resource->province_code,
+            'postal_code' => $this->when(
+                $this->isVillage(),
+                fn () => $this->resource->postal_code
+            ),
+        ];
+
+        $with = (array) $request->query('with', []);
+
+        if (\in_array('postal_codes', $with, true)) {
+            $arr['postal_codes'] = $this->when(
+                ! $this->isVillage(),
+                fn () => $this->resource->postal_codes
+            );
+        }
+
+        if (\in_array('coordinates', $with, true)) {
+            $arr['latitude'] = $this->resource->latitude;
+            $arr['longitude'] = $this->resource->longitude;
+            $arr['coordinates'] = $this->resource->coordinates;
+        }
+
+        foreach ($with as $relation) {
+            $arr[$relation] = $this->whenLoaded($relation);
+        }
+
+        return \array_filter($arr);
+    }
+
+    private function isVillage(): bool
+    {
+        return $this->resource instanceof Village;
+    }
 }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\Model as EloquentModel;
  * @property-read string $name
  * @property-read null|array $coordinates
  *
- * @method static static search(string|int $keyword)
+ * @method static static search(string $keyword)
  * @method Builder whereCode(int $code)
  * @method Builder whereName(string $name)
  *
@@ -48,12 +48,8 @@ abstract class Model extends EloquentModel implements HasCoordinate
         return \array_merge(parent::getFillable(), ['code', 'name', 'coordinates']);
     }
 
-    public function scopeSearch(Builder $query, string|int $keyword)
+    public function scopeSearch(Builder $query, string $keyword)
     {
-        if (\is_numeric($keyword)) {
-            return $query->where('code', $keyword);
-        }
-
         return $query->whereRaw(match ($this->getConnection()->getDriverName()) {
             'pgsql' => 'name ilike ?',
             'mysql' => 'lower(name) like lower(?)',

--- a/tests/Features/DistrictTest.php
+++ b/tests/Features/DistrictTest.php
@@ -2,6 +2,7 @@
 
 namespace Creasi\Tests\Features;
 
+use Creasi\Tests\Models\DistrictTest as ModelTest;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\DependsOnClass;
@@ -40,39 +41,22 @@ class DistrictTest extends TestCase
     }
 
     #[Test]
+    #[DependsOnClass(ModelTest::class)]
     #[DependsOnClass(RegencyTest::class)]
     #[DataProvider('availableQueries')]
-    public function it_shows_available_districts(?string ...$with)
+    public function it_shows_available_districts(?string ...$with): void
     {
         $response = $this->getJson($this->path(query: [
             'with' => $with,
         ]));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [self::FIELDS],
-            'links' => ['first', 'last', 'prev', 'next'],
-            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
-        ]);
-    }
-
-    #[Test]
-    #[Depends('it_shows_available_districts')]
-    public function it_shows_districts_by_selected_codes()
-    {
-        $response = $this->getJson($this->path(query: [
-            'codes' => [337503, 337504],
-        ]));
-
-        $response->assertOk()->assertJsonStructure([
-            'data' => [self::FIELDS],
-            'meta' => [],
-        ])->assertJsonCount(2, 'data');
+        $this->assertCollectionResponse($response, self::FIELDS, $with);
     }
 
     #[Test]
     #[Depends('it_shows_available_districts')]
     #[DataProvider('invalidCodes')]
-    public function it_shows_errors_for_invalid_codes(mixed $codes)
+    public function it_shows_errors_for_invalid_codes(mixed $codes): void
     {
         $response = $this->getJson($this->path(query: [
             'codes' => $codes,
@@ -83,43 +67,44 @@ class DistrictTest extends TestCase
 
     #[Test]
     #[Depends('it_shows_available_districts')]
-    public function it_shows_districts_by_search_query()
+    public function it_shows_districts_by_selected_codes(): void
+    {
+        $response = $this->getJson($this->path(query: [
+            'codes' => [337503, 337504],
+        ]));
+
+        $this->assertCollectionResponse($response, self::FIELDS)->assertJsonCount(2, 'data');
+    }
+
+    #[Test]
+    #[Depends('it_shows_available_districts')]
+    public function it_shows_districts_by_search_query(): void
     {
         $response = $this->getJson($this->path(query: [
             'search' => 'Pekalongan',
         ]));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [self::FIELDS],
-            'meta' => [],
-        ])->assertJsonCount(5, 'data');
+        $this->assertCollectionResponse($response, self::FIELDS)->assertJsonCount(5, 'data');
     }
 
     #[Test]
     #[Depends('it_shows_available_districts')]
     #[DataProvider('availableQueries')]
-    public function it_shows_single_district(?string ...$with)
+    public function it_shows_single_district(?string ...$with): void
     {
         $response = $this->getJson($this->path('337503', [
             'with' => $with,
         ]));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => self::FIELDS,
-            'meta' => [],
-        ]);
+        $this->assertSingleResponse($response, self::FIELDS, $with);
     }
 
     #[Test]
     #[Depends('it_shows_available_districts')]
-    public function it_shows_available_villages_in_a_district()
+    public function it_shows_available_villages_in_a_district(): void
     {
         $response = $this->getJson($this->path('337503/villages'));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [VillageTest::FIELDS],
-            'links' => ['first', 'last', 'prev', 'next'],
-            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
-        ]);
+        $this->assertCollectionResponse($response, VillageTest::FIELDS);
     }
 }

--- a/tests/Features/DistrictTest.php
+++ b/tests/Features/DistrictTest.php
@@ -27,6 +27,7 @@ class DistrictTest extends TestCase
             'basic request' => [],
             'include province' => ['province'],
             'include regency' => ['regency'],
+            'include villages' => ['villages'],
         ];
     }
 

--- a/tests/Features/ProvinceTest.php
+++ b/tests/Features/ProvinceTest.php
@@ -2,8 +2,10 @@
 
 namespace Creasi\Tests\Features;
 
+use Creasi\Tests\Models\ProvinceTest as ModelTest;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\DependsOnClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -42,38 +44,21 @@ class ProvinceTest extends TestCase
     }
 
     #[Test]
+    #[DependsOnClass(ModelTest::class)]
     #[DataProvider('availableQueries')]
-    public function it_shows_all_available_provinces(?string ...$with)
+    public function it_shows_all_available_provinces(?string ...$with): void
     {
         $response = $this->getJson($this->path(query: [
             'with' => $with,
         ]));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [self::FIELDS],
-            'links' => ['first', 'last', 'prev', 'next'],
-            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
-        ]);
-    }
-
-    #[Test]
-    #[Depends('it_shows_all_available_provinces')]
-    public function it_shows_provinces_by_selected_codes()
-    {
-        $response = $this->getJson($this->path(query: [
-            'codes' => [33, 32],
-        ]));
-
-        $response->assertOk()->assertJsonStructure([
-            'data' => [self::FIELDS],
-            'meta' => [],
-        ])->assertJsonCount(2, 'data');
+        $this->assertCollectionResponse($response, self::FIELDS, $with);
     }
 
     #[Test]
     #[Depends('it_shows_all_available_provinces')]
     #[DataProvider('invalidCodes')]
-    public function it_shows_errors_for_invalid_codes(mixed $codes)
+    public function it_shows_errors_for_invalid_codes(mixed $codes): void
     {
         $response = $this->getJson($this->path(query: [
             'codes' => $codes,
@@ -84,69 +69,62 @@ class ProvinceTest extends TestCase
 
     #[Test]
     #[Depends('it_shows_all_available_provinces')]
-    public function it_shows_provinces_by_search_query()
+    public function it_shows_provinces_by_selected_codes(): void
+    {
+        $response = $this->getJson($this->path(query: [
+            'codes' => [33, 32],
+        ]));
+
+        $this->assertCollectionResponse($response, self::FIELDS)->assertJsonCount(2, 'data');
+    }
+
+    #[Test]
+    #[Depends('it_shows_all_available_provinces')]
+    public function it_shows_provinces_by_search_query(): void
     {
         $response = $this->getJson($this->path(query: [
             'search' => 'Jawa Tengah',
         ]));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [self::FIELDS],
-            'meta' => [],
-        ])->assertJsonCount(1, 'data');
+        $this->assertCollectionResponse($response, self::FIELDS)->assertJsonCount(1, 'data');
     }
 
     #[Test]
     #[Depends('it_shows_all_available_provinces')]
     #[DataProvider('availableQueries')]
-    public function it_shows_single_province(?string ...$with)
+    public function it_shows_single_province(?string ...$with): void
     {
         $response = $this->getJson($this->path('33', [
             'with' => $with,
         ]));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => self::FIELDS,
-            'meta' => [],
-        ]);
+        $this->assertSingleResponse($response, self::FIELDS, $with);
     }
 
     #[Test]
     #[Depends('it_shows_all_available_provinces')]
-    public function it_shows_available_regencies_in_a_province()
+    public function it_shows_available_regencies_in_a_province(): void
     {
         $response = $this->getJson($this->path('33/regencies'));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [RegencyTest::FIELDS],
-            'links' => ['first', 'last', 'prev', 'next'],
-            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
-        ]);
+        $this->assertCollectionResponse($response, RegencyTest::FIELDS);
     }
 
     #[Test]
     #[Depends('it_shows_all_available_provinces')]
-    public function it_shows_available_districts_in_a_province()
+    public function it_shows_available_districts_in_a_province(): void
     {
         $response = $this->getJson($this->path('33/districts'));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [DistrictTest::FIELDS],
-            'links' => ['first', 'last', 'prev', 'next'],
-            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
-        ]);
+        $this->assertCollectionResponse($response, DistrictTest::FIELDS);
     }
 
     #[Test]
     #[Depends('it_shows_all_available_provinces')]
-    public function it_shows_available_villages_in_a_province()
+    public function it_shows_available_villages_in_a_province(): void
     {
         $response = $this->getJson($this->path('33/villages'));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [VillageTest::FIELDS],
-            'links' => ['first', 'last', 'prev', 'next'],
-            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
-        ]);
+        $this->assertCollectionResponse($response, VillageTest::FIELDS);
     }
 }

--- a/tests/Features/ProvinceTest.php
+++ b/tests/Features/ProvinceTest.php
@@ -27,6 +27,9 @@ class ProvinceTest extends TestCase
             'basic request' => [],
             'include postal_codes' => ['postal_codes'],
             'include coordinates' => ['coordinates'],
+            'include regencies' => ['regencies'],
+            'include districts' => ['districts'],
+            'include villages' => ['villages'],
         ];
     }
 

--- a/tests/Features/ProvinceTest.php
+++ b/tests/Features/ProvinceTest.php
@@ -2,6 +2,8 @@
 
 namespace Creasi\Tests\Features;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -9,99 +11,139 @@ use PHPUnit\Framework\Attributes\Test;
 #[Group('provinces')]
 class ProvinceTest extends TestCase
 {
+    public const FIELDS = [
+        'code',
+        'name',
+        // 'latitude',
+        // 'longitude',
+        // 'coordinates'
+    ];
+
     protected $path = 'nusa/provinces';
 
-    protected $fields = ['code', 'name', 'latitude', 'longitude', 'coordinates'];
+    public static function availableQueries(): array
+    {
+        return [
+            'basic request' => [],
+            'include postal_codes' => ['postal_codes'],
+            'include coordinates' => ['coordinates'],
+        ];
+    }
+
+    public static function invalidCodes(): array
+    {
+        return [
+            'array of non-numeric code' => [['foo']],
+            'non-array of numeric code' => [33],
+        ];
+    }
 
     #[Test]
-    public function it_shows_all_available_provinces()
+    #[DataProvider('availableQueries')]
+    public function it_shows_all_available_provinces(?string ...$with)
     {
-        $response = $this->getJson($this->path);
+        $response = $this->getJson($this->path(query: [
+            'with' => $with,
+        ]));
 
         $response->assertOk()->assertJsonStructure([
-            'data' => [$this->fields],
+            'data' => [self::FIELDS],
             'links' => ['first', 'last', 'prev', 'next'],
             'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
         ]);
     }
 
     #[Test]
+    #[Depends('it_shows_all_available_provinces')]
     public function it_shows_provinces_by_selected_codes()
     {
         $response = $this->getJson($this->path(query: [
             'codes' => [33, 32],
         ]));
 
-        $response->assertOk()->assertJsonCount(2, 'data');
+        $response->assertOk()->assertJsonStructure([
+            'data' => [self::FIELDS],
+            'meta' => [],
+        ])->assertJsonCount(2, 'data');
     }
 
     #[Test]
-    public function it_shows_errors_when_codes_item_is_not_numeric()
+    #[Depends('it_shows_all_available_provinces')]
+    #[DataProvider('invalidCodes')]
+    public function it_shows_errors_for_invalid_codes(mixed $codes)
     {
         $response = $this->getJson($this->path(query: [
-            'codes' => ['foo'],
+            'codes' => $codes,
         ]));
 
         $response->assertUnprocessable();
     }
 
     #[Test]
-    public function it_shows_errors_when_codes_is_not_an_array()
-    {
-        $response = $this->getJson($this->path(query: [
-            'codes' => 33,
-        ]));
-
-        $response->assertUnprocessable();
-    }
-
-    #[Test]
+    #[Depends('it_shows_all_available_provinces')]
     public function it_shows_provinces_by_search_query()
     {
         $response = $this->getJson($this->path(query: [
             'search' => 'Jawa Tengah',
         ]));
 
-        $response->assertOk()->assertJsonCount(1, 'data');
+        $response->assertOk()->assertJsonStructure([
+            'data' => [self::FIELDS],
+            'meta' => [],
+        ])->assertJsonCount(1, 'data');
     }
 
     #[Test]
-    public function it_shows_single_province()
+    #[Depends('it_shows_all_available_provinces')]
+    #[DataProvider('availableQueries')]
+    public function it_shows_single_province(?string ...$with)
     {
-        $response = $this->getJson($this->path('33'));
+        $response = $this->getJson($this->path('33', [
+            'with' => $with,
+        ]));
 
         $response->assertOk()->assertJsonStructure([
-            'data' => $this->fields,
+            'data' => self::FIELDS,
+            'meta' => [],
         ]);
     }
 
     #[Test]
+    #[Depends('it_shows_all_available_provinces')]
     public function it_shows_available_regencies_in_a_province()
     {
         $response = $this->getJson($this->path('33/regencies'));
 
         $response->assertOk()->assertJsonStructure([
-            'data' => [$this->fields],
+            'data' => [RegencyTest::FIELDS],
+            'links' => ['first', 'last', 'prev', 'next'],
+            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
         ]);
     }
 
     #[Test]
+    #[Depends('it_shows_all_available_provinces')]
     public function it_shows_available_districts_in_a_province()
     {
         $response = $this->getJson($this->path('33/districts'));
 
         $response->assertOk()->assertJsonStructure([
-            'data' => [$this->fields],
+            'data' => [DistrictTest::FIELDS],
+            'links' => ['first', 'last', 'prev', 'next'],
+            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
         ]);
     }
 
     #[Test]
-    public function it_shows_available_villages_province()
+    #[Depends('it_shows_all_available_provinces')]
+    public function it_shows_available_villages_in_a_province()
     {
         $response = $this->getJson($this->path('33/villages'));
 
         $response->assertOk()->assertJsonStructure([
-            'data' => [$this->fields],
+            'data' => [VillageTest::FIELDS],
+            'links' => ['first', 'last', 'prev', 'next'],
+            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
         ]);
     }
 }

--- a/tests/Features/RegencyTest.php
+++ b/tests/Features/RegencyTest.php
@@ -2,6 +2,7 @@
 
 namespace Creasi\Tests\Features;
 
+use Creasi\Tests\Models\RegencyTest as ModelTest;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\DependsOnClass;
@@ -44,36 +45,22 @@ class RegencyTest extends TestCase
     }
 
     #[Test]
+    #[DependsOnClass(ModelTest::class)]
     #[DependsOnClass(ProvinceTest::class)]
     #[DataProvider('availableQueries')]
-    public function it_shows_all_available_regencies(?string ...$with)
+    public function it_shows_all_available_regencies(?string ...$with): void
     {
         $response = $this->getJson($this->path(query: [
             'with' => $with,
         ]));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [self::FIELDS],
-            'links' => ['first', 'last', 'prev', 'next'],
-            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
-        ]);
-    }
-
-    #[Test]
-    #[Depends('it_shows_all_available_regencies')]
-    public function it_shows_regencies_by_selected_codes()
-    {
-        $response = $this->getJson($this->path(query: [
-            'codes' => [3375, 3325],
-        ]));
-
-        $response->assertOk()->assertJsonCount(2, 'data');
+        $this->assertCollectionResponse($response, self::FIELDS, $with);
     }
 
     #[Test]
     #[Depends('it_shows_all_available_regencies')]
     #[DataProvider('invalidCodes')]
-    public function it_shows_errors_for_invalid_codes(mixed $codes)
+    public function it_shows_errors_for_invalid_codes(mixed $codes): void
     {
         $response = $this->getJson($this->path(query: [
             'codes' => $codes,
@@ -84,56 +71,53 @@ class RegencyTest extends TestCase
 
     #[Test]
     #[Depends('it_shows_all_available_regencies')]
-    public function it_shows_regencies_by_search_query()
+    public function it_shows_regencies_by_selected_codes(): void
+    {
+        $response = $this->getJson($this->path(query: [
+            'codes' => [3375, 3325],
+        ]));
+
+        $this->assertCollectionResponse($response, self::FIELDS)->assertJsonCount(2, 'data');
+    }
+
+    #[Test]
+    #[Depends('it_shows_all_available_regencies')]
+    public function it_shows_regencies_by_search_query(): void
     {
         $response = $this->getJson($this->path(query: [
             'search' => 'Pekalongan',
         ]));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [self::FIELDS],
-            'meta' => [],
-        ])->assertJsonCount(2, 'data');
+        $this->assertCollectionResponse($response, self::FIELDS)->assertJsonCount(2, 'data');
     }
 
     #[Test]
     #[Depends('it_shows_all_available_regencies')]
     #[DataProvider('availableQueries')]
-    public function it_shows_single_regency(?string ...$with)
+    public function it_shows_single_regency(?string ...$with): void
     {
         $response = $this->getJson($this->path('3375', [
             'with' => $with,
         ]));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => self::FIELDS,
-            'meta' => [],
-        ]);
+        $this->assertSingleResponse($response, self::FIELDS, $with);
     }
 
     #[Test]
     #[Depends('it_shows_all_available_regencies')]
-    public function it_shows_available_districts_in_a_regency()
+    public function it_shows_available_districts_in_a_regency(): void
     {
         $response = $this->getJson($this->path('3375/districts'));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [DistrictTest::FIELDS],
-            'links' => ['first', 'last', 'prev', 'next'],
-            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
-        ]);
+        $this->assertCollectionResponse($response, DistrictTest::FIELDS);
     }
 
     #[Test]
     #[Depends('it_shows_all_available_regencies')]
-    public function it_shows_available_villages_in_a_regency()
+    public function it_shows_available_villages_in_a_regency(): void
     {
         $response = $this->getJson($this->path('3375/villages'));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [VillageTest::FIELDS],
-            'links' => ['first', 'last', 'prev', 'next'],
-            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
-        ]);
+        $this->assertCollectionResponse($response, VillageTest::FIELDS);
     }
 }

--- a/tests/Features/RegencyTest.php
+++ b/tests/Features/RegencyTest.php
@@ -27,9 +27,11 @@ class RegencyTest extends TestCase
     {
         return [
             'basic request' => [],
-            'include province' => ['province'],
             'include postal_codes' => ['postal_codes'],
             'include coordinates' => ['coordinates'],
+            'include province' => ['province'],
+            'include districts' => ['districts'],
+            'include villages' => ['villages'],
         ];
     }
 

--- a/tests/Features/TestCase.php
+++ b/tests/Features/TestCase.php
@@ -3,6 +3,7 @@
 namespace Creasi\Tests\Features;
 
 use Creasi\Tests\TestCase as BaseTestCase;
+use Illuminate\Testing\TestResponse;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -22,4 +23,31 @@ abstract class TestCase extends BaseTestCase
     abstract public static function availableQueries(): array;
 
     abstract public static function invalidCodes(): array;
+
+    /**
+     * Assert that the response has a 200 "OK" status code and given JSON structure.
+     */
+    protected function assertSingleResponse(TestResponse $response, array $fields): TestResponse
+    {
+        // $fields = \array_merge($fields, $with);
+
+        return $response->assertOk()->assertJsonStructure([
+            'data' => $fields,
+            'meta' => [],
+        ]);
+    }
+
+    /**
+     * Assert that the response has a 200 "OK" status code and given JSON structure.
+     */
+    protected function assertCollectionResponse(TestResponse $response, array $fields): TestResponse
+    {
+        // $fields = \array_merge($fields, $with);
+
+        return $response->assertOk()->assertJsonStructure([
+            'data' => [$fields],
+            'links' => ['first', 'last', 'prev', 'next'],
+            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
+        ]);
+    }
 }

--- a/tests/Features/TestCase.php
+++ b/tests/Features/TestCase.php
@@ -4,7 +4,7 @@ namespace Creasi\Tests\Features;
 
 use Creasi\Tests\TestCase as BaseTestCase;
 
-class TestCase extends BaseTestCase
+abstract class TestCase extends BaseTestCase
 {
     protected $path = '';
 
@@ -18,4 +18,8 @@ class TestCase extends BaseTestCase
 
         return $path;
     }
+
+    abstract public static function availableQueries(): array;
+
+    abstract public static function invalidCodes(): array;
 }

--- a/tests/Features/VillageTest.php
+++ b/tests/Features/VillageTest.php
@@ -2,6 +2,7 @@
 
 namespace Creasi\Tests\Features;
 
+use Creasi\Tests\Models\VillageTest as ModelTest;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\DependsOnClass;
@@ -42,39 +43,22 @@ class VillageTest extends TestCase
     }
 
     #[Test]
+    #[DependsOnClass(ModelTest::class)]
     #[DependsOnClass(DistrictTest::class)]
     #[DataProvider('availableQueries')]
-    public function it_shows_available_villages(?string ...$with)
+    public function it_shows_available_villages(?string ...$with): void
     {
         $response = $this->getJson($this->path(query: [
             'with' => $with,
         ]));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [self::FIELDS],
-            'links' => ['first', 'last', 'prev', 'next'],
-            'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
-        ]);
-    }
-
-    #[Test]
-    #[Depends('it_shows_available_villages')]
-    public function it_shows_villages_by_selected_codes()
-    {
-        $response = $this->getJson($this->path(query: [
-            'codes' => [3375031004, 3375031006],
-        ]));
-
-        $response->assertOk()->assertJsonStructure([
-            'data' => [self::FIELDS],
-            'meta' => [],
-        ])->assertJsonCount(2, 'data');
+        $this->assertCollectionResponse($response, self::FIELDS, $with);
     }
 
     #[Test]
     #[Depends('it_shows_available_villages')]
     #[DataProvider('invalidCodes')]
-    public function it_shows_errors_for_invalid_codes(mixed $codes)
+    public function it_shows_errors_for_invalid_codes(mixed $codes): void
     {
         $response = $this->getJson($this->path(query: [
             'codes' => $codes,
@@ -85,29 +69,35 @@ class VillageTest extends TestCase
 
     #[Test]
     #[Depends('it_shows_available_villages')]
-    public function it_shows_villages_by_search_query()
+    public function it_shows_villages_by_selected_codes(): void
+    {
+        $response = $this->getJson($this->path(query: [
+            'codes' => [3375031004, 3375031006],
+        ]));
+
+        $this->assertCollectionResponse($response, self::FIELDS)->assertJsonCount(2, 'data');
+    }
+
+    #[Test]
+    #[Depends('it_shows_available_villages')]
+    public function it_shows_villages_by_search_query(): void
     {
         $response = $this->getJson($this->path(query: [
             'search' => 'Padukuhan Kraton',
         ]));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => [self::FIELDS],
-            'meta' => [],
-        ])->assertJsonCount(1, 'data');
+        $this->assertCollectionResponse($response, self::FIELDS)->assertJsonCount(1, 'data');
     }
 
     #[Test]
     #[Depends('it_shows_available_villages')]
     #[DataProvider('availableQueries')]
-    public function it_shows_single_village(?string ...$with)
+    public function it_shows_single_village(?string ...$with): void
     {
         $response = $this->getJson($this->path('3375031006', [
             'with' => $with,
         ]));
 
-        $response->assertOk()->assertJsonStructure([
-            'data' => self::FIELDS,
-        ]);
+        $this->assertSingleResponse($response, self::FIELDS, $with);
     }
 }

--- a/tests/Features/VillageTest.php
+++ b/tests/Features/VillageTest.php
@@ -108,6 +108,6 @@ class VillageTest extends TestCase
 
         $response->assertOk()->assertJsonStructure([
             'data' => self::FIELDS,
-        ])->dump();
+        ]);
     }
 }

--- a/tests/Models/AddressTest.php
+++ b/tests/Models/AddressTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Creasi\Tests\Models;
+
+use Creasi\Nusa\Contracts\Address as AddressContract;
+use Creasi\Nusa\Models\Address;
+use Creasi\Tests\Fixtures\HasManyAddresses;
+use Creasi\Tests\Fixtures\HasOneAddress;
+use Creasi\Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\DependsExternal;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+#[Group('models')]
+#[Group('addresses')]
+class AddressTest extends TestCase
+{
+    use WithFaker;
+
+    /**
+     * @param  Collection<int, Village>  $villages
+     */
+    #[Test]
+    #[DependsExternal(VillageTest::class, 'it_should_has_many_villages')]
+    public function it_may_accociate_with_address(Collection $villages): AddressContract
+    {
+        $village = $villages->random()->first();
+
+        $address = $this->app->make(AddressContract::class)->create([
+            'line' => $this->faker->streetAddress(),
+        ]);
+
+        $address->associateWith($village);
+
+        $this->assertSame($village->province, $address->province);
+        $this->assertNull($address->addressable);
+
+        return $address->fresh();
+    }
+
+    #[Test]
+    #[Depends('it_may_accociate_with_address')]
+    public function may_has_many_addresses(Address $address): void
+    {
+        $addressable = new HasManyAddresses();
+
+        $addressable->save();
+
+        $addressable->addresses()->save($address);
+
+        $this->assertCount(1, $addressable->addresses);
+    }
+
+    #[Test]
+    #[Depends('it_may_accociate_with_address')]
+    public function may_has_one_address(Address $address): void
+    {
+        $addressable = new HasOneAddress();
+
+        $addressable->save();
+
+        $addressable->address()->save($address);
+
+        $this->assertInstanceOf(AddressContract::class, $addressable->address);
+    }
+}

--- a/tests/Models/DistrictTest.php
+++ b/tests/Models/DistrictTest.php
@@ -11,8 +11,10 @@ use Creasi\Nusa\Contracts\Village;
 use Creasi\Nusa\Models\District;
 use Creasi\Tests\TestCase;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\DependsExternal;
+use PHPUnit\Framework\Attributes\DependsOnClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -20,13 +22,30 @@ use PHPUnit\Framework\Attributes\Test;
 #[Group('districts')]
 class DistrictTest extends TestCase
 {
+    public static function searchProvider(): array
+    {
+        return [
+            'by name' => ['Pekalongan'],
+        ];
+    }
+
+    #[Test]
+    #[DependsOnClass(RegencyTest::class)]
+    #[DataProvider('searchProvider')]
+    public function it_should_be_able_to_search(string $keyword): void
+    {
+        $district = District::search($keyword)->first();
+
+        $this->assertNotNull($district);
+    }
+
     /**
      * @param  Collection<int, District>  $districts
      * @return Collection<int, District>
      */
     #[Test]
     #[DependsExternal(ProvinceTest::class, 'it_should_has_many_districts')]
-    public function it_should_has_many_districts(Collection $districts)
+    public function it_should_has_many_districts(Collection $districts): Collection
     {
         $districts->each(function (District $district) {
             $this->assertIsInt($district->code, 'Code should be int');
@@ -43,7 +62,7 @@ class DistrictTest extends TestCase
      */
     #[Test]
     #[Depends('it_should_has_many_districts')]
-    public function it_should_belongs_to_province(Collection $districts)
+    public function it_should_belongs_to_province(Collection $districts): void
     {
         $districts->each(function (District $district) {
             $this->assertInstanceOf(Province::class, $district->province);
@@ -55,7 +74,7 @@ class DistrictTest extends TestCase
      */
     #[Test]
     #[Depends('it_should_has_many_districts')]
-    public function it_should_belongs_to_regency(Collection $regencies)
+    public function it_should_belongs_to_regency(Collection $regencies): void
     {
         $regencies->each(function (District $district) {
             $this->assertInstanceOf(Regency::class, $district->regency);
@@ -67,7 +86,7 @@ class DistrictTest extends TestCase
      */
     #[Test]
     #[Depends('it_should_has_many_districts')]
-    public function it_should_has_many_villages(Collection $districts)
+    public function it_should_has_many_villages(Collection $districts): void
     {
         $districts->each(function (District $district) {
             $this->assertTrue($district->villages->every(fn ($vil) => $vil instanceof Village));

--- a/tests/Models/ProvinceTest.php
+++ b/tests/Models/ProvinceTest.php
@@ -9,10 +9,12 @@ use Creasi\Nusa\Contracts\Province as ProvinceContract;
 use Creasi\Nusa\Contracts\Regency;
 use Creasi\Nusa\Contracts\Village;
 use Creasi\Nusa\Models\Province;
+use Creasi\Tests\ServiceProviderTest;
 use Creasi\Tests\TestCase;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\DependsOnClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -20,7 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 #[Group('provinces')]
 class ProvinceTest extends TestCase
 {
-    public static function searchProvider()
+    public static function searchProvider(): array
     {
         return [
             'by name' => ['Jawa'],
@@ -28,21 +30,21 @@ class ProvinceTest extends TestCase
     }
 
     #[Test]
+    #[DependsOnClass(ServiceProviderTest::class)]
     #[DataProvider('searchProvider')]
-    public function it_should_be_able_to_search(string|int $keyword)
+    public function it_should_be_able_to_search(string $keyword): void
     {
         $province = Province::search($keyword)->first();
 
         $this->assertNotNull($province);
     }
 
+    /**
+     * @return Collection<int, Province>
+     */
     #[Test]
-    public function it_should_be_true()
+    public function it_should_be_true(): Collection
     {
-        if (! env('GIT_BRANCH')) {
-            $this->artisan('nusa:sync');
-        }
-
         $provinces = Province::with([
             'regencies' => function ($query) {
                 $query->take(10);
@@ -70,10 +72,11 @@ class ProvinceTest extends TestCase
 
     /**
      * @param  Collection<int, Province>  $provinces
+     * @return Collection<int, Province>
      */
     #[Test]
     #[Depends('it_should_be_true')]
-    public function it_should_has_many_regencies(Collection $provinces)
+    public function it_should_has_many_regencies(Collection $provinces): Collection
     {
         $regencies = collect();
 
@@ -88,10 +91,11 @@ class ProvinceTest extends TestCase
 
     /**
      * @param  Collection<int, Province>  $provinces
+     * @return Collection<int, Province>
      */
     #[Test]
     #[Depends('it_should_be_true')]
-    public function it_should_has_many_districts(Collection $provinces)
+    public function it_should_has_many_districts(Collection $provinces): Collection
     {
         $districts = \collect();
 
@@ -106,10 +110,11 @@ class ProvinceTest extends TestCase
 
     /**
      * @param  Collection<int, Province>  $provinces
+     * @return Collection<int, Province>
      */
     #[Test]
     #[Depends('it_should_be_true')]
-    public function it_should_has_many_villages(Collection $provinces)
+    public function it_should_has_many_villages(Collection $provinces): Collection
     {
         $villages = \collect();
 

--- a/tests/Models/ProvinceTest.php
+++ b/tests/Models/ProvinceTest.php
@@ -23,8 +23,7 @@ class ProvinceTest extends TestCase
     public static function searchProvider()
     {
         return [
-            'by code' => [33],
-            'by name' => ['Jawa Tengah'],
+            'by name' => ['Jawa'],
         ];
     }
 

--- a/tests/Models/RegencyTest.php
+++ b/tests/Models/RegencyTest.php
@@ -24,7 +24,6 @@ class RegencyTest extends TestCase
     public static function searchProvider()
     {
         return [
-            'by code' => [3375],
             'by name' => ['Pekalongan'],
         ];
     }

--- a/tests/Models/RegencyTest.php
+++ b/tests/Models/RegencyTest.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\DependsExternal;
+use PHPUnit\Framework\Attributes\DependsOnClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -21,7 +22,7 @@ use PHPUnit\Framework\Attributes\Test;
 #[Group('regencies')]
 class RegencyTest extends TestCase
 {
-    public static function searchProvider()
+    public static function searchProvider(): array
     {
         return [
             'by name' => ['Pekalongan'],
@@ -29,12 +30,13 @@ class RegencyTest extends TestCase
     }
 
     #[Test]
+    #[DependsOnClass(ProvinceTest::class)]
     #[DataProvider('searchProvider')]
-    public function it_should_be_able_to_search(string|int $keyword)
+    public function it_should_be_able_to_search(string $keyword): void
     {
-        $province = Regency::search($keyword)->first();
+        $regency = Regency::search($keyword)->first();
 
-        $this->assertNotNull($province);
+        $this->assertNotNull($regency);
     }
 
     /**
@@ -43,7 +45,7 @@ class RegencyTest extends TestCase
      */
     #[Test]
     #[DependsExternal(ProvinceTest::class, 'it_should_has_many_regencies')]
-    public function it_should_has_many_regencies(Collection $regencies)
+    public function it_should_has_many_regencies(Collection $regencies): Collection
     {
         $regencies->each(function (Regency $regency) {
             $this->assertIsInt($regency->code, 'Code should be int');
@@ -63,7 +65,7 @@ class RegencyTest extends TestCase
      */
     #[Test]
     #[Depends('it_should_has_many_regencies')]
-    public function it_should_belongs_to_province(Collection $regencies)
+    public function it_should_belongs_to_province(Collection $regencies): void
     {
         $regencies->each(function (Regency $regency) {
             $this->assertInstanceOf(Province::class, $regency->province);
@@ -75,7 +77,7 @@ class RegencyTest extends TestCase
      */
     #[Test]
     #[Depends('it_should_has_many_regencies')]
-    public function it_should_has_many_districts(Collection $regencies)
+    public function it_should_has_many_districts(Collection $regencies): void
     {
         $regencies->each(function (Regency $regency) {
             $this->assertTrue($regency->districts->every(fn ($dis) => $dis instanceof District));
@@ -87,7 +89,7 @@ class RegencyTest extends TestCase
      */
     #[Test]
     #[Depends('it_should_has_many_regencies')]
-    public function it_should_has_many_villages(Collection $regencies)
+    public function it_should_has_many_villages(Collection $regencies): void
     {
         $regencies->each(function (Regency $regency) {
             $this->assertTrue($regency->villages->every(fn ($vil) => $vil instanceof Village));

--- a/tests/Models/VillageTest.php
+++ b/tests/Models/VillageTest.php
@@ -11,8 +11,10 @@ use Creasi\Nusa\Contracts\Village as VillageContract;
 use Creasi\Nusa\Models\Village;
 use Creasi\Tests\TestCase;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\DependsExternal;
+use PHPUnit\Framework\Attributes\DependsOnClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -20,13 +22,30 @@ use PHPUnit\Framework\Attributes\Test;
 #[Group('villages')]
 class VillageTest extends TestCase
 {
+    public static function searchProvider(): array
+    {
+        return [
+            'by name' => ['Kraton'],
+        ];
+    }
+
+    #[Test]
+    #[DependsOnClass(DistrictTest::class)]
+    #[DataProvider('searchProvider')]
+    public function it_should_be_able_to_search(string $keyword): void
+    {
+        $village = Village::search($keyword)->first();
+
+        $this->assertNotNull($village);
+    }
+
     /**
      * @param  Collection<int, Village>  $villages
      * @return Collection<int, Village>
      */
     #[Test]
     #[DependsExternal(ProvinceTest::class, 'it_should_has_many_villages')]
-    public function it_should_has_many_villages(Collection $villages)
+    public function it_should_has_many_villages(Collection $villages): Collection
     {
         $villages->each(function (Village $village) {
             $this->assertIsInt($village->code, 'Code should be int');
@@ -43,7 +62,7 @@ class VillageTest extends TestCase
      */
     #[Test]
     #[Depends('it_should_has_many_villages')]
-    public function it_should_belongs_to_province(Collection $villages)
+    public function it_should_belongs_to_province(Collection $villages): void
     {
         $villages->each(function (Village $village) {
             $this->assertInstanceOf(Province::class, $village->province);
@@ -55,7 +74,7 @@ class VillageTest extends TestCase
      */
     #[Test]
     #[Depends('it_should_has_many_villages')]
-    public function it_should_belongs_to_regency(Collection $villages)
+    public function it_should_belongs_to_regency(Collection $villages): void
     {
         $villages->each(function (Village $village) {
             $this->assertInstanceOf(Regency::class, $village->regency);
@@ -67,7 +86,7 @@ class VillageTest extends TestCase
      */
     #[Test]
     #[Depends('it_should_has_many_villages')]
-    public function it_should_belongs_to_district(Collection $villages)
+    public function it_should_belongs_to_district(Collection $villages): void
     {
         $villages->each(function (Village $village) {
             $this->assertInstanceOf(District::class, $village->district);

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -4,67 +4,21 @@ declare(strict_types=1);
 
 namespace Creasi\Tests;
 
-use Creasi\Nusa\Contracts\Address as AddressContract;
-use Creasi\Nusa\Models\Address;
-use Creasi\Nusa\Models\Village;
-use Creasi\Tests\Fixtures\HasManyAddresses;
-use Creasi\Tests\Fixtures\HasOneAddress;
-use Creasi\Tests\Models\ProvinceTest;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Collection;
-use PHPUnit\Framework\Attributes\Depends;
-use PHPUnit\Framework\Attributes\DependsExternal;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 
+#[Group('api')]
+#[Group('models')]
+#[Group('serviceProvider')]
 class ServiceProviderTest extends TestCase
 {
-    use WithFaker;
-
-    /**
-     * @param  Collection<int, Village>  $villages
-     * @return Collection<int, Village>
-     */
     #[Test]
-    #[DependsExternal(ProvinceTest::class, 'it_should_has_many_villages')]
-    public function it_may_accociate_with_address(Collection $villages)
+    public function it_should_be_true(): void
     {
-        $village = $villages->random()->first();
+        if (! env('GIT_BRANCH')) {
+            $this->artisan('nusa:sync');
+        }
 
-        $address = $this->app->make(AddressContract::class)->create([
-            'line' => $this->faker->streetAddress(),
-        ]);
-
-        $address->associateWith($village);
-
-        $this->assertSame($village->province, $address->province);
-        $this->assertNull($address->addressable);
-
-        return $address->fresh();
-    }
-
-    #[Test]
-    #[Depends('it_may_accociate_with_address')]
-    public function may_has_many_addresses(Address $address)
-    {
-        $addressable = new HasManyAddresses();
-
-        $addressable->save();
-
-        $addressable->addresses()->save($address);
-
-        $this->assertCount(1, $addressable->addresses);
-    }
-
-    #[Test]
-    #[Depends('it_may_accociate_with_address')]
-    public function may_has_one_address(Address $address)
-    {
-        $addressable = new HasOneAddress();
-
-        $addressable->save();
-
-        $addressable->address()->save($address);
-
-        $this->assertInstanceOf(AddressContract::class, $addressable->address);
+        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
Now `postal_codes` and `coordinates` field are no longer shown by default
instead, you'll need to add `?with[]=coordinates` or `?with[]=postal_codes`
query string to your end point URL.

`with` field also support relations fields, e.g. `/villages?with[]=province`
to get the `province` object from `villages` resource

Field `with` itself is an array of string that consists of
- `coordinates` : available for Province & Regency resources
- `postal_codes` : available for Province, Regency & District resources
- `province` : available for Regency, District - Village resources
- `regency` : available for District & Village resources 
- `regencies` : available for Province resource 
- `district` : available for Village resource
- `districts` : available for Province & Regency resources 
- `villages` : available for Province, Regency & District resources 

