### PR TITLE
Fix: False positive issue on PR #28

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9003
+    }
+  ]
+}

--- a/src/Http/Controllers/DistrictController.php
+++ b/src/Http/Controllers/DistrictController.php
@@ -16,6 +16,8 @@ final class DistrictController
 
     public function index(NusaRequest $request)
     {
+        $request->relations($this->model);
+
         return NusaResource::collection($request->apply($this->model));
     }
 
@@ -23,7 +25,7 @@ final class DistrictController
     {
         $district = $this->model->findOrFail($district);
 
-        $district->load($request->relations($district));
+        $request->relations($district);
 
         return new NusaResource($district);
     }

--- a/src/Http/Controllers/ProvinceController.php
+++ b/src/Http/Controllers/ProvinceController.php
@@ -23,7 +23,7 @@ final class ProvinceController
 
     public function show(NusaRequest $request, int $province)
     {
-        $province = $this->model->find($province);
+        $province = $this->model->findOrFail($province);
 
         $request->relations($province);
 

--- a/src/Http/Controllers/ProvinceController.php
+++ b/src/Http/Controllers/ProvinceController.php
@@ -16,6 +16,8 @@ final class ProvinceController
 
     public function index(NusaRequest $request)
     {
+        $request->relations($this->model);
+
         return NusaResource::collection($request->apply($this->model));
     }
 
@@ -23,7 +25,7 @@ final class ProvinceController
     {
         $province = $this->model->find($province);
 
-        $province->load($request->relations($province));
+        $request->relations($province);
 
         return new NusaResource($province);
     }

--- a/src/Http/Controllers/RegencyController.php
+++ b/src/Http/Controllers/RegencyController.php
@@ -16,6 +16,8 @@ final class RegencyController
 
     public function index(NusaRequest $request)
     {
+        $request->relations($this->model);
+
         return NusaResource::collection($request->apply($this->model));
     }
 
@@ -23,7 +25,7 @@ final class RegencyController
     {
         $regency = $this->model->findOrFail($regency);
 
-        $regency->load($request->relations($regency));
+        $request->relations($regency);
 
         return new NusaResource($regency);
     }

--- a/src/Http/Controllers/VillageController.php
+++ b/src/Http/Controllers/VillageController.php
@@ -16,6 +16,8 @@ final class VillageController
 
     public function index(NusaRequest $request)
     {
+        $request->relations($this->model);
+
         return NusaResource::collection($request->apply($this->model));
     }
 
@@ -23,7 +25,7 @@ final class VillageController
     {
         $village = $this->model->findOrFail($village);
 
-        $village->load($request->relations($village));
+        $request->relations($village);
 
         return new NusaResource($village);
     }

--- a/src/Http/Requests/NusaRequest.php
+++ b/src/Http/Requests/NusaRequest.php
@@ -43,6 +43,13 @@ final class NusaRequest extends FormRequest
      */
     public function relations($model): array
     {
-        return \array_filter((array) $this->query('with', []), fn (string $relate) => \method_exists($model, $relate));
+        $relations = \array_filter(
+            (array) $this->query('with', []),
+            fn (string $relate) => \method_exists($model, $relate)
+        );
+
+        $model->load($relations);
+
+        return $relations;
     }
 }

--- a/tests/Features/TestCase.php
+++ b/tests/Features/TestCase.php
@@ -27,12 +27,12 @@ abstract class TestCase extends BaseTestCase
     /**
      * Assert that the response has a 200 "OK" status code and given JSON structure.
      */
-    protected function assertSingleResponse(TestResponse $response, array $fields): TestResponse
+    protected function assertSingleResponse(TestResponse $response, array $fields, array $with = []): TestResponse
     {
-        // $fields = \array_merge($fields, $with);
+        $fields = \array_merge($fields, $with);
 
         return $response->assertOk()->assertJsonStructure([
-            'data' => $fields,
+            'data' => \array_filter($fields),
             'meta' => [],
         ]);
     }
@@ -45,7 +45,7 @@ abstract class TestCase extends BaseTestCase
         // $fields = \array_merge($fields, $with);
 
         return $response->assertOk()->assertJsonStructure([
-            'data' => [$fields],
+            'data' => [\array_filter($fields)],
             'links' => ['first', 'last', 'prev', 'next'],
             'meta' => ['current_page', 'from', 'last_page', 'links', 'path', 'per_page', 'to', 'total'],
         ]);


### PR DESCRIPTION
### Known issue #28 : 

`with[]=postal_codes` dan `with[]=coordinates` tidak menghasilkan response yang semestinya

Diketahui root cause nya adalah

https://github.com/creasico/laravel-nusa/blob/c903b993faa4583c2857cb4457b8d4039665484d/src/Http/Resources/NusaResource.php#L27-L39

Di baris 29-39 meng-overwrite output dari variable `$arr` di baris 27.