### PR TITLE
fix(dev): fix issue regarding upstream artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,8 @@ jobs:
 
       - name: Import databases
         run: |
-          ./vendor/bin/testbench nusa:import
+          ./vendor/bin/testbench nusa:import --ansi
+          ./vendor/bin/testbench nusa:stat -dw --ansi
           git status -s resources
 
       # - name: Get file changed
@@ -93,16 +94,13 @@ jobs:
       #     exclude_submodules: true
       #     # files: resources/**
 
-      - name: Stat databases
-        run: |
-          ./vendor/bin/testbench nusa:stat --diff
-          ./vendor/bin/testbench nusa:stat > /dev/null
-
       - name: Upload current stat
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v4
         with:
           name: upstream-stats
           path: tests/stats.json
+          if-no-files-found: ignore
 
   tests:
     name: Test on PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }} DB ${{ matrix.db }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,9 @@ jobs:
         ports:
           - 3306:3306
 
+    permissions:
+      actions: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -70,16 +73,19 @@ jobs:
           restore-keys: php-8.1-10.x--composer-
 
       - name: Download previous stat
-        uses: actions/download-artifact@v4
+        uses: dawidd6/action-download-artifact@v4
         with:
+          branch: main
           name: upstream-stats
-          path: tests/stats.json
+          path: tests
 
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 
       - name: Import databases
-        run: ./vendor/bin/testbench nusa:import
+        run: |
+          ./vendor/bin/testbench nusa:import
+          git status -s resources
 
       # - name: Get file changed
       #   uses: tj-actions/changed-files@v45
@@ -91,7 +97,6 @@ jobs:
         run: |
           ./vendor/bin/testbench nusa:stat --diff
           ./vendor/bin/testbench nusa:stat > /dev/null
-          git status -s resources
 
       - name: Upload current stat
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         ]
     },
     "lint-staged": {
-        "{config,database,src,scripts,tests}/**/*.php": [
+        "{config,database,src,tests,workbench}/**/*.php": [
             "php vendor/bin/pint --preset laravel"
         ]
     },

--- a/workbench/app/Console/CommandHelpers.php
+++ b/workbench/app/Console/CommandHelpers.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Workbench\App\Console;
+
+/**
+ * @mixin \Illuminate\Console\Command
+ */
+trait CommandHelpers
+{
+    private bool $ciGroup = false;
+
+    private function group(string $title): void
+    {
+        if (env('CI') === null) {
+            return;
+        }
+
+        $this->endGroup();
+
+        $this->line('::group::'.$title);
+        $this->ciGroup = true;
+    }
+
+    private function endGroup(): void
+    {
+        if (env('CI') === null) {
+            return;
+        }
+
+        if ($this->ciGroup) {
+            $this->line('::endgroup::');
+            $this->ciGroup = false;
+        }
+    }
+}

--- a/workbench/app/Console/CommandHelpers.php
+++ b/workbench/app/Console/CommandHelpers.php
@@ -2,12 +2,25 @@
 
 namespace Workbench\App\Console;
 
+use Illuminate\Support\Stringable;
+
 /**
  * @mixin \Illuminate\Console\Command
  */
 trait CommandHelpers
 {
     private bool $ciGroup = false;
+
+    private function libPath(string ...$paths): Stringable
+    {
+        $path = \dirname(__DIR__).'/../..';
+
+        if (! empty($paths)) {
+            $path .= '/'.implode(DIRECTORY_SEPARATOR, $paths);
+        }
+
+        return str(\realpath($path) ?: null);
+    }
 
     private function group(string $title): void
     {

--- a/workbench/app/Console/DatabaseImport.php
+++ b/workbench/app/Console/DatabaseImport.php
@@ -16,15 +16,11 @@ class DatabaseImport extends Command
 
     protected $description = 'Import upstream database';
 
-    private string $libPath;
-
     private PDO $conn;
 
     public function __construct()
     {
         parent::__construct();
-
-        $this->libPath = \realpath(\dirname(__DIR__).'/../..');
 
         try {
             $conn = DB::connection('upstream');
@@ -110,8 +106,8 @@ class DatabaseImport extends Command
         foreach ($paths as $path) {
             $this->line(" - Importing '{$path}'");
 
-            if ($query = file_get_contents("{$this->libPath}/workbench/submodules/{$path}")) {
-                /*dd($query);*/
+            if ($query = file_get_contents((string) $this->libPath('workbench/submodules', $path))) {
+                /* dd($query); */
                 $this->query($query);
             }
         }
@@ -125,10 +121,10 @@ class DatabaseImport extends Command
     private function writeCsv(string $filename, Collection $content): void
     {
         $this->ensureDirectoryExists(
-            $path = str("{$this->libPath}/resources/static/{$filename}.csv")
+            $path = $this->libPath('resources/static', $filename.'.csv')
         );
 
-        $this->line(" - Writing: '{$path->substr(strlen($this->libPath) + 1)}'");
+        $this->line(" - Writing: '{$path->substr(strlen($this->libPath()) + 1)}'");
 
         $csv = [
             array_keys($content[0]),
@@ -155,10 +151,10 @@ class DatabaseImport extends Command
     private function writeJson(string $filename, Collection $content): void
     {
         $this->ensureDirectoryExists(
-            $path = str("{$this->libPath}/resources/static/{$filename}.json")
+            $path = $this->libPath('resources/static', $filename.'.json')
         );
 
-        $this->line(" - Writing: '{$path->substr(strlen($this->libPath) + 1)}'");
+        $this->line(" - Writing: '{$path->substr(strlen($this->libPath()) + 1)}'");
 
         file_put_contents((string) $path, json_encode($content->map(function ($value) {
             if (isset($value['coordinates'])) {

--- a/workbench/app/Console/DatabaseImport.php
+++ b/workbench/app/Console/DatabaseImport.php
@@ -10,6 +10,8 @@ use Workbench\App\Support\Normalizer;
 
 class DatabaseImport extends Command
 {
+    use CommandHelpers;
+
     protected $signature = 'nusa:import';
 
     protected $description = 'Import upstream database';
@@ -17,8 +19,6 @@ class DatabaseImport extends Command
     private string $libPath;
 
     private PDO $conn;
-
-    private bool $ciGroup = false;
 
     public function __construct()
     {
@@ -175,30 +175,6 @@ class DatabaseImport extends Command
 
         if (! is_dir($dir)) {
             \mkdir($dir, 0755);
-        }
-    }
-
-    private function group(string $title): void
-    {
-        if (env('CI') === null) {
-            return;
-        }
-
-        $this->endGroup();
-
-        $this->line('::group::'.$title);
-        $this->ciGroup = true;
-    }
-
-    private function endGroup(): void
-    {
-        if (env('CI') === null) {
-            return;
-        }
-
-        if ($this->ciGroup) {
-            $this->line('::endgroup::');
-            $this->ciGroup = false;
         }
     }
 }


### PR DESCRIPTION
### Major changes
- [x] `nusa:stat` command no longer automatically write `stats.json` to disk instead it you require to pass `--write` option to do so
- [x] Adds shorthand option for `--diff` and `--write` on `nusa:stat` command

### Notable changes
- [x] Lint all `workbench` files and remove `scripts` directory from lint due to #100 
- [x] Show stat result once the upstream' data imported