### PR TITLE
feat: use legal area code format

### DIFF
--- a/database/migrations/0000_00_00_000000_create_nusa_tables.php
+++ b/database/migrations/0000_00_00_000000_create_nusa_tables.php
@@ -31,7 +31,7 @@ return new class extends Migration
         });
 
         Schema::create($tableNames['regencies'], function (Blueprint $table) use ($tableNames) {
-            $table->char('code', 4)->primary();
+            $table->char('code', 5)->primary();
             $table->char('province_code', 2);
             $table->string('name', 50)->index();
             $table->double('latitude')->nullable();
@@ -42,8 +42,8 @@ return new class extends Migration
         });
 
         Schema::create($tableNames['districts'], function (Blueprint $table) use ($tableNames) {
-            $table->char('code', 6)->primary();
-            $table->char('regency_code', 4);
+            $table->char('code', 8)->primary();
+            $table->char('regency_code', 5);
             $table->char('province_code', 2);
             $table->string('name', 50)->index();
             $table->double('latitude')->nullable();
@@ -55,9 +55,9 @@ return new class extends Migration
         });
 
         Schema::create($tableNames['villages'], function (Blueprint $table) use ($tableNames) {
-            $table->char('code', 10)->primary();
-            $table->char('district_code', 6);
-            $table->char('regency_code', 4);
+            $table->char('code', 13)->primary();
+            $table->char('district_code', 8);
+            $table->char('regency_code', 5);
             $table->char('province_code', 2);
             $table->string('name', 50)->index();
             $table->char('postal_code', 5)->nullable();

--- a/src/Contracts/District.php
+++ b/src/Contracts/District.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Contracts;
 
 /**
- * @property-read int $regency_code
- * @property-read int $province_code
+ * @property-read string $regency_code
+ * @property-read string $province_code
  * @property-read Province $province
  * @property-read Regency $regency
  * @property-read \Illuminate\Support\Collection<int, Village> $villages

--- a/src/Contracts/Regency.php
+++ b/src/Contracts/Regency.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Contracts;
 
 /**
- * @property-read int $province_code
+ * @property-read string $province_code
  * @property-read Province $province
  * @property-read \Illuminate\Support\Collection<int, District> $districts
  * @property-read \Illuminate\Support\Collection<int, Village> $villages

--- a/src/Contracts/Village.php
+++ b/src/Contracts/Village.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Contracts;
 
 /**
- * @property-read int $district_code
- * @property-read int $regency_code
- * @property-read int $province_code
+ * @property-read string $district_code
+ * @property-read string $regency_code
+ * @property-read string $province_code
  * @property-read null|int $postal_code
  * @property-read Province $province
  * @property-read Regency $regency

--- a/src/Http/Controllers/DistrictController.php
+++ b/src/Http/Controllers/DistrictController.php
@@ -21,7 +21,7 @@ final class DistrictController
         return NusaResource::collection($request->apply($this->model));
     }
 
-    public function show(NusaRequest $request, int $district)
+    public function show(NusaRequest $request, string $district)
     {
         $district = $this->model->findOrFail($district);
 
@@ -30,7 +30,7 @@ final class DistrictController
         return new NusaResource($district);
     }
 
-    public function villages(NusaRequest $request, int $district)
+    public function villages(NusaRequest $request, string $district)
     {
         $district = $this->model->findOrFail($district);
 

--- a/src/Http/Controllers/ProvinceController.php
+++ b/src/Http/Controllers/ProvinceController.php
@@ -21,7 +21,7 @@ final class ProvinceController
         return NusaResource::collection($request->apply($this->model));
     }
 
-    public function show(NusaRequest $request, int $province)
+    public function show(NusaRequest $request, string $province)
     {
         $province = $this->model->findOrFail($province);
 
@@ -30,7 +30,7 @@ final class ProvinceController
         return new NusaResource($province);
     }
 
-    public function regencies(NusaRequest $request, int $province)
+    public function regencies(NusaRequest $request, string $province)
     {
         $province = $this->model->findOrFail($province);
 
@@ -39,7 +39,7 @@ final class ProvinceController
         );
     }
 
-    public function districts(NusaRequest $request, int $province)
+    public function districts(NusaRequest $request, string $province)
     {
         $province = $this->model->findOrFail($province);
 
@@ -48,7 +48,7 @@ final class ProvinceController
         );
     }
 
-    public function villages(NusaRequest $request, int $province)
+    public function villages(NusaRequest $request, string $province)
     {
         $province = $this->model->findOrFail($province);
 

--- a/src/Http/Controllers/RegencyController.php
+++ b/src/Http/Controllers/RegencyController.php
@@ -21,7 +21,7 @@ final class RegencyController
         return NusaResource::collection($request->apply($this->model));
     }
 
-    public function show(NusaRequest $request, int $regency)
+    public function show(NusaRequest $request, string $regency)
     {
         $regency = $this->model->findOrFail($regency);
 
@@ -30,7 +30,7 @@ final class RegencyController
         return new NusaResource($regency);
     }
 
-    public function districts(NusaRequest $request, int $regency)
+    public function districts(NusaRequest $request, string $regency)
     {
         $regency = $this->model->findOrFail($regency);
 
@@ -39,7 +39,7 @@ final class RegencyController
         );
     }
 
-    public function villages(NusaRequest $request, int $regency)
+    public function villages(NusaRequest $request, string $regency)
     {
         $regency = $this->model->findOrFail($regency);
 

--- a/src/Http/Controllers/VillageController.php
+++ b/src/Http/Controllers/VillageController.php
@@ -21,7 +21,7 @@ final class VillageController
         return NusaResource::collection($request->apply($this->model));
     }
 
-    public function show(NusaRequest $request, int $village)
+    public function show(NusaRequest $request, string $village)
     {
         $village = $this->model->findOrFail($village);
 

--- a/src/Http/Requests/NusaRequest.php
+++ b/src/Http/Requests/NusaRequest.php
@@ -15,7 +15,7 @@ final class NusaRequest extends FormRequest
             'with' => ['nullable', 'array'],
             'with.*' => ['string'],
             'codes' => ['nullable', 'array'],
-            'codes.*' => ['numeric'],
+            'codes.*' => ['string'],
             'search' => ['nullable', 'string'],
             'postal_code' => ['nullable', 'numeric', 'digits:5'],
             'page' => ['nullable', 'numeric'],

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -10,15 +10,25 @@ use Creasi\Nusa\Contracts\Province;
 use Creasi\Nusa\Contracts\Regency;
 use Creasi\Nusa\Contracts\Village;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 /**
+ * @template TAddressableModel of \Creasi\Nusa\Contracts\Address
+ *
  * @mixin \Illuminate\Contracts\Database\Eloquent\Builder
  */
 class Address extends EloquentModel implements AddressContract
 {
+    /** @use Concerns\WithDistrict<static> */
     use Concerns\WithDistrict;
+
+    /** @use Concerns\WithProvince<static> */
     use Concerns\WithProvince;
+
+    /** @use Concerns\WithRegency<static> */
     use Concerns\WithRegency;
+
+    /** @use Concerns\WithVillage<static> */
     use Concerns\WithVillage;
 
     public function getCasts()
@@ -63,9 +73,9 @@ class Address extends EloquentModel implements AddressContract
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     * @return MorphTo<TAddressableModel>
      */
-    public function addressable()
+    public function addressable(): MorphTo
     {
         return $this->morphTo('addressable');
     }

--- a/src/Models/Concerns/WithAddress.php
+++ b/src/Models/Concerns/WithAddress.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace Creasi\Nusa\Models\Concerns;
 
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
 /**
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template TAddressableModel of \Creasi\Nusa\Contracts\Address
+ *
  * @mixin \Creasi\Nusa\Contracts\HasAddress
  */
 trait WithAddress
 {
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\MorphOne|\Creasi\Nusa\Contracts\Address
+     * @return MorphOne<TAddressableModel, TDeclaringModel>
      */
-    public function address()
+    public function address(): MorphOne
     {
         return $this->morphOne(\config('creasi.nusa.addressable'), 'addressable');
     }

--- a/src/Models/Concerns/WithAddresses.php
+++ b/src/Models/Concerns/WithAddresses.php
@@ -7,12 +7,15 @@ namespace Creasi\Nusa\Models\Concerns;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 /**
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template TAddressableModel of \Creasi\Nusa\Contracts\Address
+ *
  * @mixin \Creasi\Nusa\Contracts\HasAddresses
  */
 trait WithAddresses
 {
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany|\Creasi\Nusa\Contracts\Address
+     * @return MorphMany<TAddressableModel, TDeclaringModel>
      */
     public function addresses(): MorphMany
     {

--- a/src/Models/Concerns/WithCoordinate.php
+++ b/src/Models/Concerns/WithCoordinate.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Models\Concerns;
 
 /**
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
  * @mixin \Creasi\Nusa\Contracts\HasCoordinate
  */
 trait WithCoordinate

--- a/src/Models/Concerns/WithDistrict.php
+++ b/src/Models/Concerns/WithDistrict.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Models\Concerns;
 
 use Creasi\Nusa\Models\District;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
  * @property-read District|\Creasi\Nusa\Contracts\District $district
  *
  * @mixin \Illuminate\Database\Eloquent\Model
@@ -24,9 +27,9 @@ trait WithDistrict
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo<District, TDeclaringModel>
      */
-    public function district()
+    public function district(): BelongsTo
     {
         return $this->belongsTo(District::class, $this->districtKeyName());
     }

--- a/src/Models/Concerns/WithDistrict.php
+++ b/src/Models/Concerns/WithDistrict.php
@@ -18,10 +18,6 @@ trait WithDistrict
      */
     final protected function initializeWithDistrict(): void
     {
-        $this->mergeCasts([
-            $this->districtKeyName() => 'int',
-        ]);
-
         $this->mergeFillable([
             $this->districtKeyName(),
         ]);

--- a/src/Models/Concerns/WithDistricts.php
+++ b/src/Models/Concerns/WithDistricts.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Models\Concerns;
 
 use Creasi\Nusa\Models\District;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
  * @property-read \Illuminate\Database\Eloquent\Collection<int, District|\Creasi\Nusa\Contracts\District> $districts
  *
  * @mixin \Illuminate\Database\Eloquent\Model
@@ -14,9 +17,9 @@ use Creasi\Nusa\Models\District;
 trait WithDistricts
 {
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany|\Creasi\Nusa\Contracts\District
+     * @return HasMany<District, TDeclaringModel>
      */
-    public function districts()
+    public function districts(): HasMany
     {
         return $this->hasMany(District::class);
     }

--- a/src/Models/Concerns/WithProvince.php
+++ b/src/Models/Concerns/WithProvince.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Models\Concerns;
 
 use Creasi\Nusa\Models\Province;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
  * @property-read Province|\Creasi\Nusa\Contracts\Province $province
  *
  * @mixin \Illuminate\Database\Eloquent\Model
@@ -24,9 +27,9 @@ trait WithProvince
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo<Province, TDeclaringModel>
      */
-    public function province()
+    public function province(): BelongsTo
     {
         return $this->belongsTo(Province::class, $this->provinceKeyName());
     }

--- a/src/Models/Concerns/WithProvince.php
+++ b/src/Models/Concerns/WithProvince.php
@@ -18,10 +18,6 @@ trait WithProvince
      */
     final protected function initializeWithProvince(): void
     {
-        $this->mergeCasts([
-            $this->provinceKeyName() => 'int',
-        ]);
-
         $this->mergeFillable([
             $this->provinceKeyName(),
         ]);

--- a/src/Models/Concerns/WithRegency.php
+++ b/src/Models/Concerns/WithRegency.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Models\Concerns;
 
 use Creasi\Nusa\Models\Regency;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
  * @property-read Regency|\Creasi\Nusa\Contracts\Regency $regency
  *
  * @mixin \Illuminate\Database\Eloquent\Model
@@ -24,9 +27,9 @@ trait WithRegency
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo<Regency, TDeclaringModel>
      */
-    public function regency()
+    public function regency(): BelongsTo
     {
         return $this->belongsTo(Regency::class, $this->regencyKeyName());
     }

--- a/src/Models/Concerns/WithRegency.php
+++ b/src/Models/Concerns/WithRegency.php
@@ -18,10 +18,6 @@ trait WithRegency
      */
     final protected function initializeWithRegency(): void
     {
-        $this->mergeCasts([
-            $this->regencyKeyName() => 'int',
-        ]);
-
         $this->mergeFillable([
             $this->regencyKeyName(),
         ]);

--- a/src/Models/Concerns/WithVillage.php
+++ b/src/Models/Concerns/WithVillage.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Models\Concerns;
 
 use Creasi\Nusa\Models\Village;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
  * @property-read Village|\Creasi\Nusa\Contracts\Village $village
  *
  * @mixin \Illuminate\Database\Eloquent\Model
@@ -24,9 +27,9 @@ trait WithVillage
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo|\Creasi\Nusa\Contracts\Village
+     * @return BelongsTo<Village, TDeclaringModel>
      */
-    public function village()
+    public function village(): BelongsTo
     {
         return $this->belongsTo(Village::class, $this->villageKeyName());
     }

--- a/src/Models/Concerns/WithVillage.php
+++ b/src/Models/Concerns/WithVillage.php
@@ -18,10 +18,6 @@ trait WithVillage
      */
     final protected function initializeWithVillage(): void
     {
-        $this->mergeCasts([
-            $this->villageKeyName() => 'int',
-        ]);
-
         $this->mergeFillable([
             $this->villageKeyName(),
         ]);

--- a/src/Models/Concerns/WithVillages.php
+++ b/src/Models/Concerns/WithVillages.php
@@ -6,8 +6,11 @@ namespace Creasi\Nusa\Models\Concerns;
 
 use Creasi\Nusa\Models\Village;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
  * @property-read \Illuminate\Database\Eloquent\Collection<int, int> $postal_codes
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Village|\Creasi\Nusa\Contracts\Village> $villages
  *
@@ -26,9 +29,9 @@ trait WithVillages
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany|\Creasi\Nusa\Contracts\Village
+     * @return HasMany<Village, TDeclaringModel>
      */
-    public function villages()
+    public function villages(): HasMany
     {
         return $this->hasMany(Village::class);
     }

--- a/src/Models/District.php
+++ b/src/Models/District.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Models;
 
 use Creasi\Nusa\Contracts\District as DistrictContract;
-use Creasi\Nusa\Models\Concerns\WithProvince;
-use Creasi\Nusa\Models\Concerns\WithRegency;
-use Creasi\Nusa\Models\Concerns\WithVillages;
 
 class District extends Model implements DistrictContract
 {
-    use WithProvince;
-    use WithRegency;
-    use WithVillages;
+    /** @use Concerns\WithProvince<static> */
+    use Concerns\WithProvince;
+
+    /** @use Concerns\WithRegency<static> */
+    use Concerns\WithRegency;
+
+    /** @use Concerns\WithVillages<static> */
+    use Concerns\WithVillages;
 
     protected $fillable = [];
 

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Models;
 
 use Creasi\Nusa\Contracts\HasCoordinate;
-use Creasi\Nusa\Models\Concerns\WithCoordinate;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 
@@ -22,7 +21,7 @@ use Illuminate\Database\Eloquent\Model as EloquentModel;
  */
 abstract class Model extends EloquentModel implements HasCoordinate
 {
-    use WithCoordinate;
+    use Concerns\WithCoordinate;
 
     public $incrementing = false;
 

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -30,6 +30,8 @@ abstract class Model extends EloquentModel implements HasCoordinate
 
     protected $primaryKey = 'code';
 
+    protected $keyType = 'string';
+
     public function getConnectionName()
     {
         return \config('creasi.nusa.connection');
@@ -38,7 +40,6 @@ abstract class Model extends EloquentModel implements HasCoordinate
     public function getCasts()
     {
         return \array_merge(parent::getCasts(), [
-            'code' => 'int',
             'coordinates' => 'array',
         ]);
     }

--- a/src/Models/Province.php
+++ b/src/Models/Province.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Models;
 
 use Creasi\Nusa\Contracts\Province as ProvinceContract;
-use Creasi\Nusa\Models\Concerns\WithDistricts;
-use Creasi\Nusa\Models\Concerns\WithVillages;
 
 /**
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Regency> $regencies
  */
 class Province extends Model implements ProvinceContract
 {
-    use WithDistricts;
-    use WithVillages;
+    /** @use Concerns\WithDistricts<static> */
+    use Concerns\WithDistricts;
+
+    /** @use Concerns\WithVillages<static> */
+    use Concerns\WithVillages;
 
     protected $fillable = [];
 

--- a/src/Models/Regency.php
+++ b/src/Models/Regency.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Models;
 
 use Creasi\Nusa\Contracts\Regency as RegencyContract;
-use Creasi\Nusa\Models\Concerns\WithDistricts;
-use Creasi\Nusa\Models\Concerns\WithProvince;
-use Creasi\Nusa\Models\Concerns\WithVillages;
 
 class Regency extends Model implements RegencyContract
 {
-    use WithDistricts;
-    use WithProvince;
-    use WithVillages;
+    /** @use Concerns\WithPWithDistrictsrovince<static> */
+    use Concerns\WithDistricts;
+
+    /** @use Concerns\WithProvince<static> */
+    use Concerns\WithProvince;
+
+    /** @use Concerns\WithVillages<static> */
+    use Concerns\WithVillages;
 
     protected $fillable = [];
 

--- a/src/Models/Village.php
+++ b/src/Models/Village.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace Creasi\Nusa\Models;
 
 use Creasi\Nusa\Contracts\Village as VillageContract;
-use Creasi\Nusa\Models\Concerns\WithDistrict;
-use Creasi\Nusa\Models\Concerns\WithProvince;
-use Creasi\Nusa\Models\Concerns\WithRegency;
 
 class Village extends Model implements VillageContract
 {
-    use WithDistrict;
-    use WithProvince;
-    use WithRegency;
+    /** @use Concerns\WithDistrict<static> */
+    use Concerns\WithDistrict;
+
+    /** @use Concerns\WithProvince<static> */
+    use Concerns\WithProvince;
+
+    /** @use Concerns\WithRegency<static> */
+    use Concerns\WithRegency;
 
     protected $fillable = ['postal_code'];
 

--- a/tests/Features/DistrictTest.php
+++ b/tests/Features/DistrictTest.php
@@ -18,6 +18,8 @@ class DistrictTest extends TestCase
         'name',
         'regency_code',
         'province_code',
+        'latitude',
+        'longitude',
     ];
 
     protected $path = 'nusa/districts';

--- a/tests/Features/DistrictTest.php
+++ b/tests/Features/DistrictTest.php
@@ -43,8 +43,8 @@ class DistrictTest extends TestCase
     public static function invalidCodes(): array
     {
         return [
-            'array of non-numeric code' => [['foo']],
-            'non-array of numeric code' => [337503],
+            // 'array of non-numeric code' => [['foo']],
+            'non-array of numeric code' => ['33.75.03'],
         ];
     }
 
@@ -78,7 +78,7 @@ class DistrictTest extends TestCase
     public function it_shows_districts_by_selected_codes(): void
     {
         $response = $this->getJson($this->path(query: [
-            'codes' => [337503, 337504],
+            'codes' => ['33.75.03', '33.75.04'],
         ]));
 
         $this->assertCollectionResponse($response, self::FIELDS)->assertJsonCount(2, 'data');
@@ -100,7 +100,7 @@ class DistrictTest extends TestCase
     #[DataProvider('availableQueries')]
     public function it_shows_single_district(?string ...$with): void
     {
-        $response = $this->getJson($this->path('337503', [
+        $response = $this->getJson($this->path('33.75.03', [
             'with' => $with,
         ]));
 
@@ -112,7 +112,7 @@ class DistrictTest extends TestCase
     #[DataProvider('possibleSearchVillages')]
     public function it_shows_available_villages_in_a_district(?string $search): void
     {
-        $response = $this->getJson($this->path('337503/villages', [
+        $response = $this->getJson($this->path('33.75.03/villages', [
             'search' => $search,
         ]));
 

--- a/tests/Features/ProvinceTest.php
+++ b/tests/Features/ProvinceTest.php
@@ -62,7 +62,7 @@ class ProvinceTest extends TestCase
     public static function invalidCodes(): array
     {
         return [
-            'array of non-numeric code' => [['foo']],
+            // 'array of non-numeric code' => [['foo']],
             'non-array of numeric code' => [33],
         ];
     }

--- a/tests/Features/ProvinceTest.php
+++ b/tests/Features/ProvinceTest.php
@@ -16,8 +16,8 @@ class ProvinceTest extends TestCase
     public const FIELDS = [
         'code',
         'name',
-        // 'latitude',
-        // 'longitude',
+        'latitude',
+        'longitude',
         // 'coordinates'
     ];
 
@@ -63,7 +63,7 @@ class ProvinceTest extends TestCase
     {
         return [
             // 'array of non-numeric code' => [['foo']],
-            'non-array of numeric code' => [33],
+            'non-array of numeric code' => ['33'],
         ];
     }
 
@@ -96,7 +96,7 @@ class ProvinceTest extends TestCase
     public function it_shows_provinces_by_selected_codes(): void
     {
         $response = $this->getJson($this->path(query: [
-            'codes' => [33, 32],
+            'codes' => ['33', '32'],
         ]));
 
         $this->assertCollectionResponse($response, self::FIELDS)->assertJsonCount(2, 'data');

--- a/tests/Features/RegencyTest.php
+++ b/tests/Features/RegencyTest.php
@@ -17,8 +17,8 @@ class RegencyTest extends TestCase
         'code',
         'name',
         'province_code',
-        // 'latitude',
-        // 'longitude',
+        'latitude',
+        'longitude',
         // 'coordinates'
     ];
 
@@ -55,8 +55,8 @@ class RegencyTest extends TestCase
     public static function invalidCodes(): array
     {
         return [
-            'array of non-numeric code' => [['foo']],
-            'non-array of numeric code' => [3375],
+            // 'array of non-numeric code' => [['foo']],
+            'non-array of numeric code' => ['33.75'],
         ];
     }
 
@@ -90,7 +90,7 @@ class RegencyTest extends TestCase
     public function it_shows_regencies_by_selected_codes(): void
     {
         $response = $this->getJson($this->path(query: [
-            'codes' => [3375, 3325],
+            'codes' => ['33.75', '33.25'],
         ]));
 
         $this->assertCollectionResponse($response, self::FIELDS)->assertJsonCount(2, 'data');
@@ -112,7 +112,7 @@ class RegencyTest extends TestCase
     #[DataProvider('availableQueries')]
     public function it_shows_single_regency(?string ...$with): void
     {
-        $response = $this->getJson($this->path('3375', [
+        $response = $this->getJson($this->path('33.75', [
             'with' => $with,
         ]));
 
@@ -124,7 +124,7 @@ class RegencyTest extends TestCase
     #[DataProvider('possibleSearchDistricts')]
     public function it_shows_available_districts_in_a_regency(?string $search): void
     {
-        $response = $this->getJson($this->path('3326/districts', [
+        $response = $this->getJson($this->path('33.26/districts', [
             'search' => $search,
         ]));
 
@@ -136,7 +136,7 @@ class RegencyTest extends TestCase
     #[DataProvider('possibleSearchVillages')]
     public function it_shows_available_villages_in_a_regency(?string $search): void
     {
-        $response = $this->getJson($this->path('3375/villages', [
+        $response = $this->getJson($this->path('33.75/villages', [
             'search' => $search,
         ]));
 

--- a/tests/Features/VillageTest.php
+++ b/tests/Features/VillageTest.php
@@ -20,6 +20,8 @@ class VillageTest extends TestCase
         'regency_code',
         'province_code',
         'postal_code',
+        'latitude',
+        'longitude',
     ];
 
     protected $path = 'nusa/villages';

--- a/tests/Features/VillageTest.php
+++ b/tests/Features/VillageTest.php
@@ -37,8 +37,8 @@ class VillageTest extends TestCase
     public static function invalidCodes(): array
     {
         return [
-            'array of non-numeric code' => [['foo']],
-            'non-array of numeric code' => [3375031004],
+            // 'array of non-numeric code' => [['foo']],
+            'non-array of numeric code' => ['33.75.03.1004'],
         ];
     }
 
@@ -72,7 +72,7 @@ class VillageTest extends TestCase
     public function it_shows_villages_by_selected_codes(): void
     {
         $response = $this->getJson($this->path(query: [
-            'codes' => [3375031004, 3375031006],
+            'codes' => ['33.75.03.1004', '33.75.03.1006'],
         ]));
 
         $this->assertCollectionResponse($response, self::FIELDS)->assertJsonCount(2, 'data');
@@ -105,7 +105,7 @@ class VillageTest extends TestCase
     #[DataProvider('availableQueries')]
     public function it_shows_single_village(?string ...$with): void
     {
-        $response = $this->getJson($this->path('3375031006', [
+        $response = $this->getJson($this->path('33.75.03.1006', [
             'with' => $with,
         ]));
 

--- a/tests/Models/DistrictTest.php
+++ b/tests/Models/DistrictTest.php
@@ -48,7 +48,7 @@ class DistrictTest extends TestCase
     public function it_should_has_many_districts(Collection $districts): Collection
     {
         $districts->each(function (District $district) {
-            $this->assertIsString($district->code, 'Code should be int');
+            $this->assertIsString($district->code, 'Code should be string');
             // $this->assertIsFloat($district->latitude, \sprintf('Latitude of district "%s" should be float', $district->code));
             // $this->assertIsFloat($district->longitude, \sprintf('Longitude of district "%s" should be float', $district->code));
             $this->assertInstanceOf(Collection::class, $district->postal_codes, 'Postal Codes should be instance of collection');

--- a/tests/Models/DistrictTest.php
+++ b/tests/Models/DistrictTest.php
@@ -48,7 +48,7 @@ class DistrictTest extends TestCase
     public function it_should_has_many_districts(Collection $districts): Collection
     {
         $districts->each(function (District $district) {
-            $this->assertIsInt($district->code, 'Code should be int');
+            $this->assertIsString($district->code, 'Code should be int');
             // $this->assertIsFloat($district->latitude, \sprintf('Latitude of district "%s" should be float', $district->code));
             // $this->assertIsFloat($district->longitude, \sprintf('Longitude of district "%s" should be float', $district->code));
             $this->assertInstanceOf(Collection::class, $district->postal_codes, 'Postal Codes should be instance of collection');

--- a/tests/Models/ProvinceTest.php
+++ b/tests/Models/ProvinceTest.php
@@ -55,7 +55,7 @@ class ProvinceTest extends TestCase
         ])->get();
 
         $provinces->each(function (Province $province) {
-            $this->assertIsString($province->code, 'Code should be int');
+            $this->assertIsString($province->code, 'Code should be string');
             $this->assertIsFloat($province->latitude, \sprintf('Latitude of province "%s" should be float', $province->code));
             $this->assertIsFloat($province->longitude, \sprintf('Longitude of province "%s" should be float', $province->code));
             $this->assertInstanceOf(Collection::class, $province->postal_codes, 'Postal Codes should be instance of collection');

--- a/tests/Models/ProvinceTest.php
+++ b/tests/Models/ProvinceTest.php
@@ -55,7 +55,7 @@ class ProvinceTest extends TestCase
         ])->get();
 
         $provinces->each(function (Province $province) {
-            $this->assertIsInt($province->code, 'Code should be int');
+            $this->assertIsString($province->code, 'Code should be int');
             $this->assertIsFloat($province->latitude, \sprintf('Latitude of province "%s" should be float', $province->code));
             $this->assertIsFloat($province->longitude, \sprintf('Longitude of province "%s" should be float', $province->code));
             $this->assertInstanceOf(Collection::class, $province->postal_codes, 'Postal Codes should be instance of collection');

--- a/tests/Models/RegencyTest.php
+++ b/tests/Models/RegencyTest.php
@@ -48,7 +48,7 @@ class RegencyTest extends TestCase
     public function it_should_has_many_regencies(Collection $regencies): Collection
     {
         $regencies->each(function (Regency $regency) {
-            $this->assertIsInt($regency->code, 'Code should be int');
+            $this->assertIsString($regency->code, 'Code should be int');
             // Comment this out due to https://github.com/cahyadsn/wilayah/pull/47
             // $this->assertIsFloat($regency->latitude, \sprintf('Latitude of regency "%s" should be float', $regency->code));
             // $this->assertIsFloat($regency->longitude, \sprintf('Longitude of regency "%s" should be float', $regency->code));

--- a/tests/Models/RegencyTest.php
+++ b/tests/Models/RegencyTest.php
@@ -48,7 +48,7 @@ class RegencyTest extends TestCase
     public function it_should_has_many_regencies(Collection $regencies): Collection
     {
         $regencies->each(function (Regency $regency) {
-            $this->assertIsString($regency->code, 'Code should be int');
+            $this->assertIsString($regency->code, 'Code should be string');
             // Comment this out due to https://github.com/cahyadsn/wilayah/pull/47
             // $this->assertIsFloat($regency->latitude, \sprintf('Latitude of regency "%s" should be float', $regency->code));
             // $this->assertIsFloat($regency->longitude, \sprintf('Longitude of regency "%s" should be float', $regency->code));

--- a/tests/Models/VillageTest.php
+++ b/tests/Models/VillageTest.php
@@ -48,7 +48,7 @@ class VillageTest extends TestCase
     public function it_should_has_many_villages(Collection $villages): Collection
     {
         $villages->each(function (Village $village) {
-            $this->assertIsString($village->code, 'Code should be int');
+            $this->assertIsString($village->code, 'Code should be string');
             // $this->assertIsFloat($village->latitude, \sprintf('Latitude of village "%s" should be float', $village->code));
             // $this->assertIsFloat($village->longitude, \sprintf('Longitude of village "%s" should be float', $village->code));
             if ($village->postal_code) {

--- a/tests/Models/VillageTest.php
+++ b/tests/Models/VillageTest.php
@@ -48,7 +48,7 @@ class VillageTest extends TestCase
     public function it_should_has_many_villages(Collection $villages): Collection
     {
         $villages->each(function (Village $village) {
-            $this->assertIsInt($village->code, 'Code should be int');
+            $this->assertIsString($village->code, 'Code should be int');
             // $this->assertIsFloat($village->latitude, \sprintf('Latitude of village "%s" should be float', $village->code));
             // $this->assertIsFloat($village->longitude, \sprintf('Longitude of village "%s" should be float', $village->code));
             if ($village->postal_code) {

--- a/workbench/app/Console/DatabaseImport.php
+++ b/workbench/app/Console/DatabaseImport.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use PDO;
 use Symfony\Component\Finder\Finder;
-use Throwable;
 use Workbench\App\Support\Normalizer;
 
 class DatabaseImport extends Command
@@ -54,11 +53,7 @@ class DatabaseImport extends Command
             );
 
             foreach (array_chunk($values, $this->chunkSize) as $chunks) {
-                try {
-                    DB::transaction(fn () => $this->model($table)->insert($chunks));
-                } catch (Throwable $err) {
-                    logger()->error($err->getMessage(), ['exception' => $err]);
-                }
+                DB::transaction(fn () => $this->model($table)->insert($chunks));
 
                 unset($chunks);
             }

--- a/workbench/app/Support/Normalizer.php
+++ b/workbench/app/Support/Normalizer.php
@@ -54,11 +54,11 @@ class Normalizer
 
     private function toRegency(): array
     {
-        [$province_code, $code] = explode('.', $this->code, 2);
+        [$province_code] = explode('.', $this->code, 2);
 
         return [
-            'code' => (int) ($province_code.$code),
-            'province_code' => (int) $province_code,
+            'code' => $this->code,
+            'province_code' => $province_code,
             'name' => (string) str($this->name)->title(),
             'latitude' => $this->latitude,
             'longitude' => $this->longitude,
@@ -68,12 +68,12 @@ class Normalizer
 
     private function toDistrict(): array
     {
-        [$province_code, $regency_code, $code] = explode('.', $this->code, 3);
+        [$province_code, $regency_code] = explode('.', $this->code, 3);
 
         return [
-            'code' => (int) ($province_code.$regency_code.$code),
-            'regency_code' => (int) ($province_code.$regency_code),
-            'province_code' => (int) $province_code,
+            'code' => $this->code,
+            'regency_code' => $this->join($province_code, $regency_code),
+            'province_code' => $province_code,
             'name' => $this->name,
             'latitude' => $this->latitude,
             'longitude' => $this->longitude,
@@ -83,19 +83,24 @@ class Normalizer
 
     private function toVillage(): array
     {
-        [$province_code, $regency_code, $district_code, $code] = explode('.', $this->code, 4);
+        [$province_code, $regency_code, $district_code] = explode('.', $this->code, 4);
 
         return [
-            'code' => (int) ($province_code.$regency_code.$district_code.$code),
-            'district_code' => (int) ($province_code.$regency_code.$district_code),
-            'regency_code' => (int) ($province_code.$regency_code),
-            'province_code' => (int) $province_code,
+            'code' => $this->code,
+            'district_code' => $this->join($province_code, $regency_code, $district_code),
+            'regency_code' => $this->join($province_code, $regency_code),
+            'province_code' => $province_code,
             'name' => $this->name,
             'postal_code' => $this->postal_code,
             'latitude' => $this->latitude,
             'longitude' => $this->longitude,
             'coordinates' => $this->normalizeCoordinates($this->coordinates),
         ];
+    }
+
+    private function join(string ...$codes): string
+    {
+        return implode('.', $codes);
     }
 
     private function normalizeCoordinates(?array $arr)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - None.

- **Bug Fixes**
  - None.

- **Refactor**
  - Updated all region codes (province, regency, district, village) to use string formats with dot separators instead of integers across the application and tests.
  - Adjusted validation rules to expect string codes.
  - Enhanced type safety and static analysis with improved type annotations and generics in model relationships.
  - Removed automatic integer casting of region code attributes for consistency.
  - Modified database schema to support longer string codes for region identifiers.

- **Tests**
  - Updated test cases to use string-formatted codes with dots and adjusted assertions accordingly.
  - Included latitude and longitude fields in region data tests.

- **Chores**
  - Improved documentation and code annotations for better clarity and maintainability.
  - Cleaned up exception handling in database import process to allow natural error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

BREAKING CHANGE: The area codes are no longer stored as numeric value.