### PR TITLE
fix(ci): fix upstream artifact name

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -89,7 +89,12 @@ jobs:
           COLUMNS: 160
         run: |
           vendor/bin/testbench nusa:stat --ansi
-          echo "BRANCH_TOKEN=${GIT_BRANCH/\//_}" >> $GITHUB_OUTPUT
+
+          if [[ "$GIT_BRANCH" == dependabot* ]]; then
+            echo "BRANCH_TOKEN=${GIT_BRANCH##*/}" >> $GITHUB_OUTPUT
+          else
+            echo "BRANCH_TOKEN=${GIT_BRANCH//\//_}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Upload sqlite artifacts
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
Noticed on PR #232 the `upload sqlite artifacts` step is failing due to `BRANCH_TOKEN` contains invalid character which is forward slash. This PR should fix that issue by ensuring all `forward slash` characters got replaced by `underscore` and whenever `GIT_BRANCH` contains `dependabot` it should only returns the last segment, e.g. When `GIT_BRANCH` value is `dependabot/submodules/workbench/submodules/cahyadsn-wilayah-0ef886e` then `BRANCH_TOKEN` should be `cahyadsn-wilayah-0ef886e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow branch tokenization logic to optimize handling of different branch types during build processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->