### PR TITLE
fix(docs): misleading pagination documentation

### DIFF
--- a/resources/docs/en/api/districts.md
+++ b/resources/docs/en/api/districts.md
@@ -17,14 +17,14 @@ Returns a paginated list of all districts.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `page` | integer | Page number (default: 1) |
-| `per_page` | integer | Items per page (default: 15, max: 100) |
+| `per-page` | integer | Items per page (default: 15, max: 100) |
 | `search` | string | Search by name or code |
 | `codes[]` | array | Filter by specific district codes |
 
 #### Example Request
 
 ```bash
-curl "https://your-app.com/nusa/districts?search=pekalongan&per_page=10"
+curl "https://your-app.com/nusa/districts?search=pekalongan&per-page=10"
 ```
 
 ### Get District

--- a/resources/docs/en/api/overview.md
+++ b/resources/docs/en/api/overview.md
@@ -53,7 +53,7 @@ All API responses follow a consistent JSON structure:
     "current_page": 1,
     "from": 1,
     "last_page": 3,
-    "per_page": 15,
+    "per-page": 15,
     "to": 15,
     "total": 34
   }
@@ -83,13 +83,13 @@ All collection endpoints support pagination:
 - **Default page size**: 15 items
 - **Maximum page size**: 100 items
 - **Page parameter**: `?page=2`
-- **Per page parameter**: `?per_page=50`
+- **Per page parameter**: `?per-page=50`
 
 ### Pagination Example
 
 ```bash
 # Get second page with 25 items per page
-GET /nusa/provinces?page=2&per_page=25
+GET /nusa/provinces?page=2&per-page=25
 ```
 
 ## Query Parameters

--- a/resources/docs/en/api/provinces.md
+++ b/resources/docs/en/api/provinces.md
@@ -17,14 +17,14 @@ Returns a paginated list of all provinces.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `page` | integer | Page number (default: 1) |
-| `per_page` | integer | Items per page (default: 15, max: 100) |
+| `per-page` | integer | Items per page (default: 15, max: 100) |
 | `search` | string | Search by name or code |
 | `codes[]` | array | Filter by specific province codes |
 
 #### Example Request
 
 ```bash
-curl "https://your-app.com/nusa/provinces?search=jawa&per_page=10"
+curl "https://your-app.com/nusa/provinces?search=jawa&per-page=10"
 ```
 
 #### Example Response
@@ -59,7 +59,7 @@ curl "https://your-app.com/nusa/provinces?search=jawa&per_page=10"
     "current_page": 1,
     "from": 1,
     "last_page": 2,
-    "per_page": 15,
+    "per-page": 15,
     "to": 15,
     "total": 34
   }
@@ -127,7 +127,7 @@ Returns all regencies within a specific province.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `page` | integer | Page number (default: 1) |
-| `per_page` | integer | Items per page (default: 15, max: 100) |
+| `per-page` | integer | Items per page (default: 15, max: 100) |
 | `search` | string | Search regencies by name |
 
 #### Example Request
@@ -170,7 +170,7 @@ curl "https://your-app.com/nusa/provinces/33/regencies?search=semarang"
     "current_page": 1,
     "from": 1,
     "last_page": 3,
-    "per_page": 15,
+    "per-page": 15,
     "to": 15,
     "total": 35
   }
@@ -188,7 +188,7 @@ Returns all districts within a specific province.
 #### Example Request
 
 ```bash
-curl "https://your-app.com/nusa/provinces/33/districts?per_page=25"
+curl "https://your-app.com/nusa/provinces/33/districts?per-page=25"
 ```
 
 ### Get Province Villages
@@ -202,7 +202,7 @@ Returns all villages within a specific province.
 #### Example Request
 
 ```bash
-curl "https://your-app.com/nusa/provinces/33/villages?per_page=50"
+curl "https://your-app.com/nusa/provinces/33/villages?per-page=50"
 ```
 
 ## Data Attributes
@@ -324,7 +324,7 @@ $javaProvinces = $provinceService->search('jawa');
 $centralJava = $provinceService->getById('33');
 
 // Get regencies in Central Java
-$regencies = $provinceService->getRegencies('33', ['per_page' => 50]);
+$regencies = $provinceService->getRegencies('33', ['per-page' => 50]);
 ```
 
 ```python [python]
@@ -366,7 +366,7 @@ java_provinces = province_service.search("jawa")
 central_java = province_service.get_by_id("33")
 
 # Get regencies in Central Java
-regencies = province_service.get_regencies("33", {"per_page": 50})
+regencies = province_service.get_regencies("33", {"per-page": 50})
 ```
 
 :::
@@ -390,7 +390,7 @@ regencies = province_service.get_regencies("33", {"per_page": 50})
 {
   "message": "The given data was invalid.",
   "errors": {
-    "per_page": ["The per page must not be greater than 100."]
+    "per-page": ["The per page must not be greater than 100."]
   }
 }
 ```
@@ -459,7 +459,7 @@ async function getAllProvinces() {
   let hasMore = true;
   
   while (hasMore) {
-    const response = await fetch(`/nusa/provinces?page=${page}&per_page=50`);
+    const response = await fetch(`/nusa/provinces?page=${page}&per-page=50`);
     const data = await response.json();
     
     allProvinces.push(...data.data);

--- a/resources/docs/en/api/regencies.md
+++ b/resources/docs/en/api/regencies.md
@@ -17,14 +17,14 @@ Returns a paginated list of all regencies.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `page` | integer | Page number (default: 1) |
-| `per_page` | integer | Items per page (default: 15, max: 100) |
+| `per-page` | integer | Items per page (default: 15, max: 100) |
 | `search` | string | Search by name or code |
 | `codes[]` | array | Filter by specific regency codes |
 
 #### Example Request
 
 ```bash
-curl "https://your-app.com/nusa/regencies?search=jakarta&per_page=10"
+curl "https://your-app.com/nusa/regencies?search=jakarta&per-page=10"
 ```
 
 #### Example Response
@@ -52,7 +52,7 @@ curl "https://your-app.com/nusa/regencies?search=jakarta&per_page=10"
     "current_page": 1,
     "from": 1,
     "last_page": 35,
-    "per_page": 15,
+    "per-page": 15,
     "to": 15,
     "total": 514
   }
@@ -104,7 +104,7 @@ Returns all villages within a specific regency.
 #### Example Request
 
 ```bash
-curl "https://your-app.com/nusa/regencies/33.75/villages?per_page=50"
+curl "https://your-app.com/nusa/regencies/33.75/villages?per-page=50"
 ```
 
 ## Data Attributes

--- a/resources/docs/en/api/villages.md
+++ b/resources/docs/en/api/villages.md
@@ -17,14 +17,14 @@ Returns a paginated list of all villages.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `page` | integer | Page number (default: 1) |
-| `per_page` | integer | Items per page (default: 15, max: 100) |
+| `per-page` | integer | Items per page (default: 15, max: 100) |
 | `search` | string | Search by name or code |
 | `codes[]` | array | Filter by specific village codes |
 
 #### Example Request
 
 ```bash
-curl "https://your-app.com/nusa/villages?search=medono&per_page=10"
+curl "https://your-app.com/nusa/villages?search=medono&per-page=10"
 ```
 
 ### Get Village

--- a/resources/docs/en/guide/api.md
+++ b/resources/docs/en/guide/api.md
@@ -139,7 +139,7 @@ Always use pagination for large datasets:
 
 ```js
 // Good: Use pagination
-const response = await fetch('/nusa/villages?per_page=50&page=1');
+const response = await fetch('/nusa/villages?per-page=50&page=1');
 
 // Avoid: Loading all villages at once
 const response = await fetch('/nusa/villages'); // 83,762 records!
@@ -169,7 +169,7 @@ Route::prefix('v1/indonesia')->middleware(['auth:api', 'throttle:100,1'])->group
             $query->search($search);
         }
 
-        return $query->paginate($request->get('per_page', 15));
+        return $query->paginate($request->get('per-page', 15));
     });
 
     Route::get('provinces/{province}/regencies', function (string $code) {

--- a/resources/docs/id/api/districts.md
+++ b/resources/docs/id/api/districts.md
@@ -17,14 +17,14 @@ Mengembalikan daftar semua kecamatan dengan paginasi.
 | Parameter | Tipe | Deskripsi |
 |-----------|------|-------------|
 | `page` | integer | Nomor halaman (default: 1) |
-| `per_page` | integer | Item per halaman (default: 15, maks: 100) |
+| `per-page` | integer | Item per halaman (default: 15, maks: 100) |
 | `search` | string | Cari berdasarkan nama atau kode |
 | `codes[]` | array | Filter berdasarkan kode kecamatan tertentu |
 
 #### Contoh Permintaan
 
 ```bash
-curl "https://your-app.com/nusa/districts?search=pekalongan&per_page=10"
+curl "https://your-app.com/nusa/districts?search=pekalongan&per-page=10"
 ```
 
 ### Dapatkan Kecamatan

--- a/resources/docs/id/api/overview.md
+++ b/resources/docs/id/api/overview.md
@@ -53,7 +53,7 @@ Semua respon API mengikuti struktur JSON yang konsisten:
     "current_page": 1,
     "from": 1,
     "last_page": 3,
-    "per_page": 15,
+    "per-page": 15,
     "to": 15,
     "total": 34
   }
@@ -83,13 +83,13 @@ Semua *endpoint* koleksi mendukung paginasi:
 - **Ukuran halaman *default***: 15 item
 - **Ukuran halaman maksimum**: 100 item
 - **Parameter halaman**: `?page=2`
-- **Parameter per halaman**: `?per_page=50`
+- **Parameter per halaman**: `?per-page=50`
 
 ### Contoh Paginasi
 
 ```bash
 # Dapatkan halaman kedua dengan 25 item per halaman
-GET /nusa/provinces?page=2&per_page=25
+GET /nusa/provinces?page=2&per-page=25
 ```
 
 ## Parameter Kueri

--- a/resources/docs/id/api/provinces.md
+++ b/resources/docs/id/api/provinces.md
@@ -17,14 +17,14 @@ Mengembalikan daftar semua provinsi dengan paginasi.
 | Parameter | Tipe | Deskripsi |
 |-----------|------|-------------|
 | `page` | integer | Nomor halaman (default: 1) |
-| `per_page` | integer | Item per halaman (default: 15, maks: 100) |
+| `per-page` | integer | Item per halaman (default: 15, maks: 100) |
 | `search` | string | Cari berdasarkan nama atau kode |
 | `codes[]` | array | Filter berdasarkan kode provinsi tertentu |
 
 #### Contoh Permintaan
 
 ```bash
-curl "https://your-app.com/nusa/provinces?search=jawa&per_page=10"
+curl "https://your-app.com/nusa/provinces?search=jawa&per-page=10"
 ```
 
 #### Contoh Respon
@@ -59,7 +59,7 @@ curl "https://your-app.com/nusa/provinces?search=jawa&per_page=10"
     "current_page": 1,
     "from": 1,
     "last_page": 2,
-    "per_page": 15,
+    "per-page": 15,
     "to": 15,
     "total": 34
   }
@@ -127,7 +127,7 @@ Mengembalikan semua kabupaten/kota dalam provinsi tertentu.
 | Parameter | Tipe | Deskripsi |
 |-----------|------|-------------|
 | `page` | integer | Nomor halaman (default: 1) |
-| `per_page` | integer | Item per halaman (default: 15, maks: 100) |
+| `per-page` | integer | Item per halaman (default: 15, maks: 100) |
 | `search` | string | Cari kabupaten/kota berdasarkan nama |
 
 #### Contoh Permintaan
@@ -170,7 +170,7 @@ curl "https://your-app.com/nusa/provinces/33/regencies?search=semarang"
     "current_page": 1,
     "from": 1,
     "last_page": 3,
-    "per_page": 15,
+    "per-page": 15,
     "to": 15,
     "total": 35
   }
@@ -188,7 +188,7 @@ Mengembalikan semua kecamatan dalam provinsi tertentu.
 #### Contoh Permintaan
 
 ```bash
-curl "https://your-app.com/nusa/provinces/33/districts?per_page=25"
+curl "https://your-app.com/nusa/provinces/33/districts?per-page=25"
 ```
 
 ### Dapatkan Desa/Kelurahan Provinsi
@@ -202,7 +202,7 @@ Mengembalikan semua desa/kelurahan dalam provinsi tertentu.
 #### Contoh Permintaan
 
 ```bash
-curl "https://your-app.com/nusa/provinces/33/villages?per_page=50"
+curl "https://your-app.com/nusa/provinces/33/villages?per-page=50"
 ```
 
 ## Atribut Data
@@ -324,7 +324,7 @@ $javaProvinces = $provinceService->search('jawa');
 $centralJava = $provinceService->getById('33');
 
 // Dapatkan kabupaten/kota di Jawa Tengah
-$regencies = $provinceService->getRegencies('33', ['per_page' => 50]);
+$regencies = $provinceService->getRegencies('33', ['per-page' => 50]);
 ```
 
 ```python [python]
@@ -366,7 +366,7 @@ java_provinces = province_service.search("jawa");
 central_java = province_service.get_by_id("33");
 
 # Dapatkan kabupaten/kota di Jawa Tengah
-regencies = province_service.get_regencies("33", {"per_page": 50});
+regencies = province_service.get_regencies("33", {"per-page": 50});
 ```
 
 :::
@@ -390,7 +390,7 @@ regencies = province_service.get_regencies("33", {"per_page": 50});
 {
   "message": "The given data was invalid.",
   "errors": {
-    "per_page": ["The per page must not be greater than 100."]
+    "per-page": ["The per page must not be greater than 100."]
   }
 }
 ```
@@ -459,7 +459,7 @@ async function getAllProvinces() {
   let hasMore = true;
   
   while (hasMore) {
-    const response = await fetch(`/nusa/provinces?page=${page}&per_page=50`);
+    const response = await fetch(`/nusa/provinces?page=${page}&per-page=50`);
     const data = await response.json();
     
     allProvinces.push(...data.data);

--- a/resources/docs/id/api/regencies.md
+++ b/resources/docs/id/api/regencies.md
@@ -17,14 +17,14 @@ Mengembalikan daftar semua kabupaten/kota dengan paginasi.
 | Parameter | Tipe | Deskripsi |
 |-----------|------|-------------|
 | `page` | integer | Nomor halaman (default: 1) |
-| `per_page` | integer | Item per halaman (default: 15, maks: 100) |
+| `per-page` | integer | Item per halaman (default: 15, maks: 100) |
 | `search` | string | Cari berdasarkan nama atau kode |
 | `codes[]` | array | Filter berdasarkan kode kabupaten/kota tertentu |
 
 #### Contoh Permintaan
 
 ```bash
-curl "https://your-app.com/nusa/regencies?search=jakarta&per_page=10"
+curl "https://your-app.com/nusa/regencies?search=jakarta&per-page=10"
 ```
 
 #### Contoh Respon
@@ -52,7 +52,7 @@ curl "https://your-app.com/nusa/regencies?search=jakarta&per_page=10"
     "current_page": 1,
     "from": 1,
     "last_page": 35,
-    "per_page": 15,
+    "per-page": 15,
     "to": 15,
     "total": 514
   }
@@ -104,7 +104,7 @@ Mengembalikan semua desa/kelurahan dalam kabupaten/kota tertentu.
 #### Contoh Permintaan
 
 ```bash
-curl "https://your-app.com/nusa/regencies/33.75/villages?per_page=50"
+curl "https://your-app.com/nusa/regencies/33.75/villages?per-page=50"
 ```
 
 ## Atribut Data

--- a/resources/docs/id/api/villages.md
+++ b/resources/docs/id/api/villages.md
@@ -17,14 +17,14 @@ Mengembalikan daftar semua desa/kelurahan dengan paginasi.
 | Parameter | Tipe | Deskripsi |
 |-----------|------|-------------|
 | `page` | integer | Nomor halaman (default: 1) |
-| `per_page` | integer | Item per halaman (default: 15, maks: 100) |
+| `per-page` | integer | Item per halaman (default: 15, maks: 100) |
 | `search` | string | Cari berdasarkan nama atau kode |
 | `codes[]` | array | Filter berdasarkan kode desa/kelurahan tertentu |
 
 #### Contoh Permintaan
 
 ```bash
-curl "https://your-app.com/nusa/villages?search=medono&per_page=10"
+curl "https://your-app.com/nusa/villages?search=medono&per-page=10"
 ```
 
 ### Dapatkan Desa/Kelurahan

--- a/resources/docs/id/guide/api.md
+++ b/resources/docs/id/guide/api.md
@@ -139,7 +139,7 @@ Always use pagination for large datasets:
 
 ```js
 // Good: Use pagination
-const response = await fetch('/nusa/villages?per_page=50&page=1');
+const response = await fetch('/nusa/villages?per-page=50&page=1');
 
 // Avoid: Loading all villages at once
 const response = await fetch('/nusa/villages'); // 83,762 records!
@@ -169,7 +169,7 @@ Route::prefix('v1/indonesia')->middleware(['auth:api', 'throttle:100,1'])->group
             $query->search($search);
         }
 
-        return $query->paginate($request->get('per_page', 15));
+        return $query->paginate($request->get('per-page', 15));
     });
 
     Route::get('provinces/{province}/regencies', function (string $code) {


### PR DESCRIPTION
As declared here

https://github.com/creasico/laravel-nusa/blob/c4e57cb44d286c51c37141f6efd431adfddbb482/src/Http/Requests/NusaRequest.php#L14-L26

The request rules for pagination was `per-page` not `per_page`, thanks @Efrosine

close: #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation to standardize pagination parameter naming from `per_page` to `per-page` across Districts, Provinces, Regencies, and Villages endpoints in both English and Indonesian guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->