### PR TITLE
ci: make use of `ccorsi/setup-sqlite` actions

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -53,6 +53,9 @@ jobs:
           mysql -e "CREATE DATABASE $DB_DATABASE;" -u"$DB_USERNAME" -p"$DB_PASSWORD"
           mysql -e "CREATE DATABASE $UPSTREAM_DB_DATABASE;" -u"$DB_USERNAME" -p"$DB_PASSWORD"
 
+      - name: Setup SQLite
+        uses: ccorsi/setup-sqlite@v1
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -69,7 +72,6 @@ jobs:
       - name: Install dependencies
         run: |
           composer update --prefer-dist --no-interaction --no-progress
-          sudo apt-get install -y sqlite3-tools
 
       - name: Import databases
         id: imports


### PR DESCRIPTION
Due to on previous CI runs the `sql-tools` installation is seems to be broken and I have no idea why

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated build workflow to use a more reliable SQLite setup step.
  * Simplified the environment preparation process by removing a manual database tool installation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->